### PR TITLE
dtschema: Deal with the disabled nodes

### DIFF
--- a/tools/dt-validate
+++ b/tools/dt-validate
@@ -44,6 +44,18 @@ class schema_group():
                     node_matched = True
                 errors = sorted(dtschema.DTValidator(schema).iter_errors(node), key=lambda e: e.linecol)
                 for error in errors:
+
+                    # Disabled nodes might not have all the required
+                    # properties filled in, such as a regulator or a
+                    # GPIO meant to be filled at the DTS level on
+                    # boards using that particular node. Thus, if the
+                    # node is marked as disabled, let's just ignore
+                    # any error message reporting a missing property.
+                    if 'status' in node and \
+                       'disabled' in node['status'] and \
+                       'required property' in error.message:
+                        continue
+
                     print(dtschema.format_error(filename, error, verbose=verbose))
         if show_unmatched and not node_matched:
             if 'compatible' in node:


### PR DESCRIPTION
When we have a disabled nodes, we don't want to validate that all the
required properties are there, since some might be external resources
usually provided by a DTS.

However, boards DTS that don't enable that component will not be able to
provide that resource and would fail to pass the required properties check.

We'll still want to validate the existing properties though.

In order to work around it, let's just ignore any error message mentionning
a missing required property on a disabled node.

Signed-off-by: Maxime Ripard <maxime.ripard@bootlin.com>