### PR TITLE
dtschema: Also expand conditionals under anyOf and oneOf

### DIFF
--- a/dtschema/lib.py
+++ b/dtschema/lib.py
@@ -258,7 +258,7 @@ def fixup_schema(schema):
         # allOf can contain a list of if, then and else statements,
         # that in turn will contain subschemas that we'll want to
         # fixup. Let's recurse into each of those subschemas.
-        if k in ['allOf']:
+        if k in ['allOf', 'anyOf', 'oneOf']:
             for subschema in v:
                 fixup_schema(subschema)
 


### PR DESCRIPTION
allOf is not the only keyword that can hold a subschema under it, but oneOf
and anyOf are also in that case. Let's make sure it's properly dealt with.

Signed-off-by: Maxime Ripard <maxime.ripard@bootlin.com>