### PR TITLE
schemas: Revert the uniqueItems logic

### DIFF
--- a/schemas/clock/clock.yaml
+++ b/schemas/clock/clock.yaml
@@ -72,6 +72,7 @@ properties:
       only the phandle portion of the pair will appear.
 
   clock-names:
+    $ref: "/schemas/types.yaml#/definitions/string-array"
     description: List of clock input name strings sorted in the same order
       as the clocks property.  Consumers drivers will use clock-names
       to match clock input names with clocks specifiers.

--- a/schemas/dt-core.yaml
+++ b/schemas/dt-core.yaml
@@ -45,7 +45,7 @@ patternProperties:
               maximum: 8
 
   ".*-names$":
-    $ref: "types.yaml#/definitions/string-array"
+    $ref: "types.yaml#/definitions/non-unique-string-array"
 
   ".*-supply$":
     if:

--- a/schemas/gpio/gpio.yaml
+++ b/schemas/gpio/gpio.yaml
@@ -15,10 +15,7 @@ properties:
   gpio-controller:
     $ref: "/schemas/types.yaml#/definitions/flag"
   gpio-line-names:
-    # Not using string-array here because names are not unique
-    type: array
-    items: { type: string }
-    minItems: 1
+    $ref: "/schemas/types.yaml#/definitions/non-unique-string-array"
   ngpios:
     $ref: "/schemas/types.yaml#/definitions/uint32"
   gpio-reserved-ranges:

--- a/schemas/hwlock/hwlock-consumer.yaml
+++ b/schemas/hwlock/hwlock-consumer.yaml
@@ -18,7 +18,8 @@ properties:
   hwlocks:
     $ref: "/schemas/types.yaml#/definitions/phandle-array"
 
-  hwlock-names: true
+  hwlock-names:
+    $ref: "/schemas/types.yaml#/definitions/string-array"
 
 dependencies:
   hwlock-names: [ hwlocks ]

--- a/schemas/interrupts.yaml
+++ b/schemas/interrupts.yaml
@@ -18,7 +18,7 @@ properties:
   interrupts:
     $ref: "types.yaml#/definitions/uint32-matrix"
   interrupt-names:
-    $ref: "types.yaml#/definitions/string-array"
+    $ref: "/schemas/types.yaml#/definitions/string-array"
   interrupts-extended:
     $ref: "types.yaml#/definitions/phandle-array"
 dependencies:

--- a/schemas/mbox/mbox-consumer.yaml
+++ b/schemas/mbox/mbox-consumer.yaml
@@ -18,7 +18,8 @@ properties:
   mboxes:
     $ref: "/schemas/types.yaml#/definitions/phandle-array"
 
-  mbox-names: true
+  mbox-names:
+    $ref: "/schemas/types.yaml#/definitions/string-array"
 
 dependencies:
   mbox-names: [ mboxes ]

--- a/schemas/phy/phy-consumer.yaml
+++ b/schemas/phy/phy-consumer.yaml
@@ -18,7 +18,8 @@ properties:
   phys:
     $ref: "/schemas/types.yaml#/definitions/phandle-array"
 
-  phy-names: true
+  phy-names:
+    $ref: "/schemas/types.yaml#/definitions/string-array"
 
 dependencies:
   phy-names: [ phys ]

--- a/schemas/power-domain/power-domain-consumer.yaml
+++ b/schemas/power-domain/power-domain-consumer.yaml
@@ -18,7 +18,8 @@ properties:
   power-domains:
     $ref: "/schemas/types.yaml#/definitions/phandle-array"
 
-  power-domain-names: true
+  power-domain-names:
+    $ref: "/schemas/types.yaml#/definitions/string-array"
 
 dependencies:
   power-domain-names: [ power-domains ]

--- a/schemas/pwm/pwm-consumer.yaml
+++ b/schemas/pwm/pwm-consumer.yaml
@@ -18,7 +18,8 @@ properties:
   pwms:
     $ref: "/schemas/types.yaml#/definitions/phandle-array"
 
-  pwm-names: true
+  pwm-names:
+    $ref: "/schemas/types.yaml#/definitions/string-array"
 
 dependencies:
   pwm-names: [ pwms ]

--- a/schemas/reset/reset.yaml
+++ b/schemas/reset/reset.yaml
@@ -17,7 +17,8 @@ properties:
   resets:
     $ref: "/schemas/types.yaml#/definitions/phandle-array"
 
-  reset-names: true
+  reset-names:
+    $ref: "/schemas/types.yaml#/definitions/string-array"
 
 dependencies:
   reset-names: [ resets ]

--- a/schemas/types.yaml
+++ b/schemas/types.yaml
@@ -19,11 +19,14 @@ definitions:
       - type: boolean
         const: true
       - type: 'null'
-  string-array:
+  non-unique-string-array:
     type: array
     items: { type: string }
     minItems: 1
-    uniqueItems: true
+  string-array:
+    allOf:
+      - $ref: "#/definitions/non-unique-string-array"
+      - uniqueItems: true
   string:
     allOf:
       - $ref: "#/definitions/string-array"


### PR DESCRIPTION
So far, the string-array type mandates that all the items are not unique,
and this is enforced by default on all properties ending with the suffix
names.

However, a good number of the properties ending with names allow for
non-unique properties (gpio-line-names, pinctrl-names, dma-names, etc), and
this is pretty difficult to disable the unique check, which basically
requires to redefine the type all over again.

In order to ease the definitions of these properties, let's turn the logic
around. Instead, make string-array allow non-unique items, and let the
properties that don't allow it make it explicitly, which can be done pretty
easily with an allOf.

Signed-off-by: Maxime Ripard <maxime.ripard@bootlin.com>