### PR TITLE
meta-schemas: string-array: Pattern is a valid string description

### DIFF
--- a/meta-schemas/string-array.yaml
+++ b/meta-schemas/string-array.yaml
@@ -22,6 +22,7 @@ properties:
         - properties:
             enum: {}
             const: {}
+            pattern: {}
           additionalProperties: false
   enum:
     type: array


### PR DESCRIPTION
While one can specify a property as an enum, a const or a pattern, the
array meta-schemas only allows for enums or const. Let's add the patterns
as well.

Signed-off-by: Maxime Ripard <maxime.ripard@bootlin.com>