### PR TITLE
schemas: chosen: Allow ranges to be specified

### DIFF
--- a/schemas/chosen.yaml
+++ b/schemas/chosen.yaml
@@ -27,6 +27,7 @@ properties:
 
   "#address-cells": true
   "#size-cells": true
+  ranges: true
 
   bootargs:
     $ref: types.yaml#definitions/string


### PR DESCRIPTION
simple-framebuffer has a reg property that needs to be translated to the
CPU addresses in order for that CPU to access the backing buffer, even
though the mapping in usually pretty trivial.

The devicetree specification says that a missing ranges property means that
we are crossing a non-translatable boundary, and therefore we wouldn't be
able to convert that address to a CPU address.

We thus need to allow ranges to be set on chosen.

Signed-off-by: Maxime Ripard <maxime.ripard@bootlin.com>