### PR TITLE
dtschema: Fixup the schema under select

### DIFF
--- a/dtschema/lib.py
+++ b/dtschema/lib.py
@@ -250,6 +250,10 @@ def fixup_schema(schema):
         return
 
     for k,v in schema.items():
+        # select is a subschema that we want to fixup
+        if k in ['select']:
+            fixup_schema(v)
+
         # If, then and else contain subschemas that we'll want to
         # fixup as well. Let's recurse into those subschemas.
         if k in ['if', 'then', 'else']:


### PR DESCRIPTION
Even though it's pretty uncommon, select can have an arbitrary schema
underneath it.

In the case where it doesn't exists, our tools will generate an already
correct schema that doesn't need any fixup.

However, when one writes it by hand, that schemas isn't fixed up, and this
creates an odd situation where the schema under select doesn't really have
the same syntax than the rest of the schemas.

In order to address this, make sure we run the fixups on the schemas under
select if they exists.

Signed-off-by: Maxime Ripard <maxime.ripard@bootlin.com>