### PR TITLE
schemas: Validate the .*-ps properties

### DIFF
--- a/schemas/property-units.yaml
+++ b/schemas/property-units.yaml
@@ -42,6 +42,9 @@ patternProperties:
   "^.*-ns$":
     $ref: "types.yaml#/definitions/uint32-array"
     description: nanoseconds
+  "^.*-ps$":
+    $ref: "types.yaml#/definitions/uint32-array"
+    description: picoseconds
 
   # Distance
   "^.*-mm$":


### PR DESCRIPTION
Some properties are using values in picoseconds, but unlike the micro,
milli and nano-seconds variants, the picoseconds prefix wasn't added.

Let's add it.

Signed-off-by: Maxime Ripard <maxime.ripard@bootlin.com>