### PR TITLE
meta-schemas: Allow the deprecated properties

### DIFF
--- a/meta-schemas/cell.yaml
+++ b/meta-schemas/cell.yaml
@@ -55,7 +55,7 @@ single-array:
     maximum: [minimum]
 
 single-array-names:
-  enum: [ description, const, enum, minimum, maximum, default, $ref ]
+  enum: [ description, deprecated, const, enum, minimum, maximum, default, $ref ]
 
 
 single:

--- a/meta-schemas/core.yaml
+++ b/meta-schemas/core.yaml
@@ -59,6 +59,7 @@ definitions:
             - contains
             - default
             - dependencies
+            - deprecated
             - description
             - else
             - enum


### PR DESCRIPTION
The draft-8 will introduce the deprecated properties, and we want to start
using it to describe deprecation today.

Let's add it to the set of allowed properties.

Signed-off-by: Maxime Ripard <maxime.ripard@bootlin.com>