### PR TITLE
meta-schemas: gpios: Allow *-gpio properties

### DIFF
--- a/meta-schemas/gpios.yaml
+++ b/meta-schemas/gpios.yaml
@@ -19,7 +19,8 @@ properties:
     $ref: "cell.yaml#array"
 
 patternProperties:
-  '.*-gpio$': false
+  '.*-gpio$':
+    $ref: "cell.yaml#array"
   '.*-gpios$':
     $ref: "cell.yaml#array"
 


### PR DESCRIPTION
Some bindings will have some .*-gpio properties that we will want to
deprecate, but we want to still allow it bindings.

Signed-off-by: Maxime Ripard <maxime.ripard@bootlin.com>