### PR TITLE
dtschema: Remove $nodename default

### DIFF
--- a/dtschema/lib.py
+++ b/dtschema/lib.py
@@ -444,9 +444,6 @@ def process_schema(filename):
     if not 'properties' in schema.keys():
         schema['properties'] = {}
 
-    if not '$nodename' in schema['properties'].keys():
-        schema['properties']['$nodename'] = True
-
     # Add any implicit properties
     fixup_node_props(schema)
 


### PR DESCRIPTION
The current code adds a default $nodename property if it's not found in the
processed schema, and then calls the fixup functions.

Amongst those functions, add_select_schema will test whether $nodename is
found. If it is, then it will generate a select statement based on the
$nodename value, and if not, will generate a select statement set to false.

However, since we added the default before calling add_select_schema, that
latter condition never occurs, which can lead to schemas without a
compatible, $nodename or an explicit select statement being always selected
instead of never.

Such a case can happen with the recently merged in Linux 5.3 panel-common
schema.

Since no code seem to actually benefit from the default, let's remove the
default entirely.

Signed-off-by: Maxime Ripard <maxime.ripard@bootlin.com>