### PR TITLE
meta-schemas: core: Allow unevaluatedProperties in sub-schemas

### DIFF
--- a/meta-schemas/core.yaml
+++ b/meta-schemas/core.yaml
@@ -84,6 +84,7 @@ definitions:
             - then
             - type
             - typeSize
+            - unevaluatedProperties
 
     dependencies:
       "#size-cells": [ "#address-cells" ]


### PR DESCRIPTION
The unevaluatedProperties was only allowed at the top-level of the schemas
so far, let's allow it for sub-schemas as well.

Signed-off-by: Maxime Ripard <mripard@kernel.org>