### PR TITLE
schemas: phy: Add mutual dependency between phys and phy-names

### DIFF
--- a/schemas/phy/phy-consumer.yaml
+++ b/schemas/phy/phy-consumer.yaml
@@ -23,3 +23,4 @@ properties:
 
 dependencies:
   phy-names: [ phys ]
+  phys: [ phy-names ]


### PR DESCRIPTION
Documentation/devicetree/bindings/phy/phy-bindings.txt requires phy-names
to be there when phys is, so let's add that dependency.

Signed-off-by: Maxime Ripard <mripard@kernel.org>