### PR TITLE
schemas: add rng-seed node schema

### DIFF
--- a/schemas/chosen.yaml
+++ b/schemas/chosen.yaml
@@ -52,6 +52,20 @@ properties:
       the Linux EFI stub (which will populate the property itself, using
       EFI_RNG_PROTOCOL).
 
+  rng-seed:
+    $ref: types.yaml#definitions/uint8-array
+    description:
+      This property served as an entropy to add device randomness. It is parsed
+      as a byte array, e.g.
+
+      /{
+             chosen {
+                     rng-seed = /bits/ 8 <0x31 0x95 0x1b 0x3c 0xc9 0xfa ...>;
+             };
+      };
+
+      This random value should be provided by bootloader.
+
   linux,booted-from-kexec:
     type: boolean
     description:


### PR DESCRIPTION
This is based on kernel patch "fdt: add support for rng-seed".

Signed-off-by: Hsin-Yi Wang <hsinyi@chromium.org>