### PR TITLE
Add i2c scl timing

### DIFF
--- a/schemas/i2c/i2c-controller.yaml
+++ b/schemas/i2c/i2c-controller.yaml
@@ -25,5 +25,7 @@ properties:
     const: 0
 
   clock-frequency:
+    $ref: /schemas/types.yaml#/definitions/uint32
+    description: frequency of bus clock in Hz.
     minimum: 1000
     maximum: 3000000

--- a/schemas/i2c/i2c-controller.yaml
+++ b/schemas/i2c/i2c-controller.yaml
@@ -29,3 +29,13 @@ properties:
     description: frequency of bus clock in Hz.
     minimum: 1000
     maximum: 3000000
+
+  i2c-scl-rising-time-ns:
+    $ref: /schemas/types.yaml#/definitions/uint32
+    description: Number of nanoseconds the SCL signal takes to rise;
+                 t(r) in the I2C specification.
+
+  i2c-scl-falling-time-ns:
+    $ref: /schemas/types.yaml#/definitions/uint32
+    description: Number of nanoseconds the SCL signal takes to fall;
+                 t(f) in the I2C specification.


### PR DESCRIPTION
Addition in the i2c-controller.yaml:
  - addition of description for clock-frequency
  - addition of i2c-scl falling and rising time properties