### PR TITLE
clocks: Allow nodes being called "clocks"

### DIFF
--- a/meta-schemas/clocks.yaml
+++ b/meta-schemas/clocks.yaml
@@ -8,7 +8,9 @@ $schema: "http://json-schema.org/draft-07/schema#"
 
 properties:
   clocks:
-    $ref: "cell.yaml#array"
+    oneOf:
+      - $ref: "cell.yaml#array"
+      - $ref: "nodes.yaml"
   clock-ranges:
     $ref: "boolean.yaml"
   clock-indices:


### PR DESCRIPTION
Even though this is less ideal, "clocks" is both used as a generic
property name in many nodes, but also as a node name (mostly to group
multiple clocks as child nodes).
In the generic clock binding we acknowledge this and allow "clocks" to
be of type "object" as well, but fail to do so in the meta-schemas.

Add type object as an alternative to the phandles array to let DTs using
"clocks" as a node name pass the tests.

Signed-off-by: Andre Przywara <andre.przywara@arm.com>