### PR TITLE
schemas: pci-bus: add optional prop 'aspm-no-ls'

### DIFF
--- a/schemas/pci/pci-bus.yaml
+++ b/schemas/pci/pci-bus.yaml
@@ -114,6 +114,9 @@ properties:
   supports-clkreq:
     type: boolean
 
+  aspm-no-l0s:
+    type: boolean
+
   vendor-id:
     description: The PCI vendor ID
     allOf:

--- a/schemas/pci/pci-bus.yaml
+++ b/schemas/pci/pci-bus.yaml
@@ -115,6 +115,7 @@ properties:
     type: boolean
 
   aspm-no-l0s:
+    description: Disables ASPM L0s capability
     type: boolean
 
   vendor-id:


### PR DESCRIPTION
When present, indicates that the L0s component of ASPM should be disabled.