### PR TITLE
simple-bus: Allow prefix before -bus node name

### DIFF
--- a/schemas/simple-bus.yaml
+++ b/schemas/simple-bus.yaml
@@ -14,7 +14,7 @@ maintainers:
 
 properties:
   $nodename:
-    pattern: "^(bus|soc|axi|ahb|apb)(@[0-9a-f]+)?$"
+    pattern: "^([a-zA-Z][a-zA-Z0-9,+\\-._]+-bus|bus|soc|axi|ahb|apb)(@[0-9a-f]+)?$"
   compatible:
     contains:
       const: simple-bus


### PR DESCRIPTION
Some systems (Arm VExpress based) use nested busses to express their
system architecture. Just allowing generic node names like "bus"
or "soc" makes their DT files hard to read.

Allow the node name for a simple-bus node to have an explaining prefix,
so multiple busses can be distinguished more easily.

Signed-off-by: Andre Przywara <andre.przywara@arm.com>