### PR TITLE
tools/dt-validate: filter error messages from disabled subnodes

### DIFF
--- a/tools/dt-validate
+++ b/tools/dt-validate
@@ -64,6 +64,14 @@ class schema_group():
                            'required property' in error.message:
                             continue
 
+                        # Disabled subnodes might not have all the required
+                        # properties filled in let's just ignore
+                        # any error message reporting a missing property.
+                        if error.message and \
+                           'status' in error.message and \
+                           'disabled' in error.message:
+                              continue
+
                         print(dtschema.format_error(filename, error,
                                                     nodename=nodename,
                                                     verbose=verbose), file=sys.stderr)


### PR DESCRIPTION
Ignore errors on disabled subnodes.

Signed-off-by: Benjamin Gaignard <benjamin.gaignard@st.com>