### PR TITLE
meta-schemas: Allow *Properties to be any schema

### DIFF
--- a/meta-schemas/keywords.yaml
+++ b/meta-schemas/keywords.yaml
@@ -79,7 +79,11 @@ properties:
   additionalItems:
     type: boolean
   additionalProperties:
-    type: boolean
+    oneOf:
+      - type: object
+        allOf:
+          - $ref: "#/definitions/sub-schemas"
+      - type: boolean
   allOf:
     items:
       $ref: "#/definitions/sub-schemas"
@@ -140,7 +144,11 @@ properties:
   type: true
   typeSize: true
   unevaluatedProperties:
-    type: boolean
+    oneOf:
+      - type: object
+        allOf:
+          - $ref: "#/definitions/sub-schemas"
+      - type: boolean
   uniqueItems:
     type: boolean
 


### PR DESCRIPTION
According to the json-schema specification, additionalProperties and
unevaluatedProperties must be a valid JSON schema and it doesn't put
any further restrictions on them.

Match the specification by allowing both to be either boolean or a
sub-schema.

Signed-off-by: Thierry Reding <treding@nvidia.com>