### PR TITLE
meta-schemas: Document 'memory-region-names' property

### DIFF
--- a/meta-schemas/core.yaml
+++ b/meta-schemas/core.yaml
@@ -30,6 +30,8 @@ definitions:
         $ref: "string-array.yaml"
       memory-region:
         $ref: "cell.yaml#array"
+      memory-region-names:
+        $ref: "string-array.yaml"
     propertyNames:
       # Ensure DT property names are not json-schema vocabulary names
       not:
@@ -73,6 +75,7 @@ definitions:
 
     dependencies:
       "#size-cells": [ "#address-cells" ]
+      memory-region-names: [ memory-region ]
 
 properties:
   patternProperties:


### PR DESCRIPTION
The 'memory-region-names' property can be used to distinguish between
multiple entries in the 'memory-region' property. Document the new
property and model the dependency in the same way as for the 'clocks'
and 'clock-names' properties.

Signed-off-by: Thierry Reding <treding@nvidia.com>