### PR TITLE
dt-bindings document linux,ima-kexec-buffer

### DIFF
--- a/schemas/chosen.yaml
+++ b/schemas/chosen.yaml
@@ -176,6 +176,25 @@ properties:
       "linux,stdout-path" and "stdout" properties are deprecated. New platforms
       should only use the "stdout-path" property.
 
+  linux,ima-kexec-buffer:
+    allOf:
+      - $ref: types.yaml#definitions/uint64-array
+      - maxItems: 2
+    description: 
+      This property(currently used by powerpc, arm64) holds the memory range,
+      the address and the size, of the IMA measurement logs that are being carried
+      over to the kexec session.
+
+      / {
+          chosen {
+              linux,ima-kexec-buffer = <0x9 0x82000000 0x0 0x00008000>;
+                  };
+        };
+
+      This porperty does not represent real hardware, but the memory allocated for
+      carrying the IMA measurement logs. The address and the suze are expressed in
+      #address-cells and #size-cells, respectively of the root node.
+
 patternProperties:
   "^framebuffer": true
 

--- a/schemas/chosen.yaml
+++ b/schemas/chosen.yaml
@@ -182,8 +182,8 @@ properties:
       - maxItems: 2
     description: 
       This property(currently used by powerpc, arm64) holds the memory range,
-      the address and the size, of the IMA measurement logs that are being carried
-      over to the kexec session.
+      "the address and the size", of the Integrity Measuremnet Architecture(IMA)
+      measurement logs that are being carried over to the new kernel.
 
       / {
           chosen {
@@ -191,7 +191,7 @@ properties:
                   };
         };
 
-      This porperty does not represent real hardware, but the memory allocated for
+      This property does not represent real hardware, but the memory allocated for
       carrying the IMA measurement logs. The address and the suze are expressed in
       #address-cells and #size-cells, respectively of the root node.
 


### PR DESCRIPTION
Integrity measurement architecture(IMA) validates if files
have been accidentally or maliciously altered, both remotely and
locally, appraise a file's measurement against a "good" value stored
as an extended attribute, and enforce local file integrity.

IMA also measures signatures of kernel and initrd during kexec along with
the command line used for kexec. Secure boot related measurements
can also be extended based on policies. 
These measurements are critical to verify the security posture of the OS.

Carrying forward the IMA measurements is achieved by storing the IMA
measurement logs as a kernel segment and passing the memory information
in the linux,ima-kexec-buffer property.

Update device tree documentation to reflect the addition of new property
under the chosen node.