### PR TITLE
dtschema: Add assigned-clock* properties by default

### DIFF
--- a/dtschema/lib.py
+++ b/dtschema/lib.py
@@ -512,6 +512,18 @@ def fixup_node_props(schema):
         schema.setdefault('patternProperties', dict())
         schema['patternProperties']['pinctrl-[0-9]+'] = True
 
+    for key in keys:
+        if not "clocks" in key:
+            break
+
+        if "assigned-clocks" in key:
+            break
+
+    else:
+        schema['properties']['assigned-clocks'] = True
+        schema['properties']['assigned-clock-rates'] = True
+        schema['properties']['assigned-clock-parents'] = True
+
 def process_schema(filename):
     try:
         schema = load_schema(filename)


### PR DESCRIPTION
Since the assigned-clocks and related properties are handled by the core
itself most of the time, can be applied to pretty much any device node
and can depend on a specific board setup, we would eventually have to
add these properties to pretty much every YAML schema.

Add them in the tools just like status and pinctrl properties, but only
if the schema doesn't define them already.

Signed-off-by: Maxime Ripard <maxime@cerno.tech>