### PR TITLE
simple-bus: Add nonposted-mmio property

### DIFF
--- a/schemas/simple-bus.yaml
+++ b/schemas/simple-bus.yaml
@@ -7,8 +7,7 @@ $id: http://devicetree.org/schemas/simple-bus.yaml#
 $schema: http://devicetree.org/meta-schemas/core.yaml#
 
 title: simple-bus nodes
-description: |
-  Common properties always required in /memory nodes
+description: Common simple-bus binding
 
 maintainers:
   - Rob Herring <robh@kernel.org>

--- a/schemas/simple-bus.yaml
+++ b/schemas/simple-bus.yaml
@@ -24,6 +24,12 @@ properties:
     enum: [ 1, 2 ]
   "#size-cells":
     enum: [ 1, 2 ]
+  nonposted-mmio:
+    $ref: /schemas/types.yaml#/definitions/flag
+    description:
+      If present, specifies that direct children of this bus should use
+      non-posted memory accesses (i.e. a non-posted mapping mode) for MMIO
+      ranges.
 
 patternProperties:
   # All other properties should be child nodes with unit-address and 'reg'


### PR DESCRIPTION
This property indicates that nodes which are direct children of this bus
shall use non-posted (i.e. no early return) MMIO mapping modes when
mapping MMIO registers. This is a requirement that can be imposed by the
bus on otherwise generic devices.

Also included a drive-by fix for the description, which was incorrect.

Signed-off-by: Hector Martin <marcan@marcan.st>