### PR TITLE
pci-bus: Add optional EP regulator supply properties

### DIFF
--- a/schemas/pci/pci-bus.yaml
+++ b/schemas/pci/pci-bus.yaml
@@ -143,6 +143,12 @@ patternProperties:
           maxItems: 5
         minItems: 1
         maxItems: 6   # Up to 6 BARs
+      vpcie12v-supply:
+        description: 12v regulator phandle for the endpoint device
+        $ref: "/schemas/types.yaml#/definitions/phandle"
+      vpcie3v3-supply:
+        description: 3.3v regulator phandle for the endpoint device
+        $ref: "/schemas/types.yaml#/definitions/phandle"
     required:
       - reg
 


### PR DESCRIPTION
In the email thread the followed the Linux commit pullreq "[PATCH v2 1/6] dt-bindings: PCI: Add bindings for Brcmstb EP voltage regulators"
RobH said, "12V and 3.3V are standard slot supplies, can you add them to pci-bus.yaml.".  Hopefully this is acceptable.