### PR TITLE
[v2] pci-bus: Add optional EP regulator supply properties 

### DIFF
--- a/schemas/pci/pci-bus.yaml
+++ b/schemas/pci/pci-bus.yaml
@@ -145,10 +145,8 @@ patternProperties:
         maxItems: 6   # Up to 6 BARs
       vpcie12v-supply:
         description: 12v regulator phandle for the endpoint device
-        $ref: "/schemas/types.yaml#/definitions/phandle"
       vpcie3v3-supply:
         description: 3.3v regulator phandle for the endpoint device
-        $ref: "/schemas/types.yaml#/definitions/phandle"
     required:
       - reg
 

--- a/schemas/pci/pci-bus.yaml
+++ b/schemas/pci/pci-bus.yaml
@@ -143,6 +143,12 @@ patternProperties:
           maxItems: 5
         minItems: 1
         maxItems: 6   # Up to 6 BARs
+      vpcie12v-supply:
+        description: 12v regulator phandle for the endpoint device
+        $ref: "/schemas/types.yaml#/definitions/phandle"
+      vpcie3v3-supply:
+        description: 3.3v regulator phandle for the endpoint device
+        $ref: "/schemas/types.yaml#/definitions/phandle"
     required:
       - reg
 


### PR DESCRIPTION
Removed the $ref that was causing YAML test errors.