### PR TITLE
schemas: pci: Allow more than one PERST# GPIOs

### DIFF
--- a/schemas/pci/pci-bus.yaml
+++ b/schemas/pci/pci-bus.yaml
@@ -113,7 +113,7 @@ properties:
 
   reset-gpios:
     description: GPIO controlled connection to PERST# signal
-    maxItems: 1
+    maxItems: 4
 
   supports-clkreq:
     type: boolean


### PR DESCRIPTION
Due to different electrical requirements, some hardware designs
may opt to use more than one PERST# GPIO pins.

That's the case, for instance, of Hikey 970. Such hardware
uses 4 different GPIOs for PERST:

- GPIO 56 has a pullup logic from 1V8 to 2V5
  connected to a PCIe bridge chip (PEX 8606);
- GPIO 25 has a pullup logic from 1V8 to 3V3
  connected to the PERST# pin at the M.2 slot;
- GPIO 220 has a pullup logic from 1V8 to 3V3
  connected to the PERST# pin at the PCIe mini slot;
- GPIO 203 has a pullup logic from 1V8 to 3V3
  connected to the PERST# pin at the Ethernet chipset.

In order to support such kind of hardware, the pci-bus schema
should support at least 4 PERST# GPIO reset pins.

Signed-off-by: Mauro Carvalho Chehab <mchehab+huawei@kernel.org>