### PR TITLE
schemas/dt-core: Add "reserved" as valid value for status property

### DIFF
--- a/schemas/dt-core.yaml
+++ b/schemas/dt-core.yaml
@@ -35,7 +35,7 @@ properties:
     $ref: "types.yaml#/definitions/uint32-matrix"
   status:
     $ref: "types.yaml#/definitions/string"
-    enum: [ okay, disabled ]
+    enum: [ okay, disabled, reserved ]
 patternProperties:
   "^#.*-cells$":
     $ref: "types.yaml#/definitions/uint32"


### PR DESCRIPTION
As per Devicetree Specification, Release v0.3, status can have "okay",
"disabled", "reserved", "fail", "fail-sss" as valid values.

While "fail" and "fail-sss" descriptions could indicate a variable
and potentially dynamic definition, "reserved" is more clear and static
description. Lets add that to the enum list.

Signed-off-by: Nishanth Menon <nm@ti.com>