### PR TITLE
schemas: root-node: Introduce 'chassis-type' property

### DIFF
--- a/schemas/root-node.yaml
+++ b/schemas/root-node.yaml
@@ -17,6 +17,17 @@ properties:
   $nodename:
     const: "/"
   model: { "$ref" : "types.yaml#/definitions/string-array"}
+  chassis-type:
+    items:
+      - const: desktop
+      - const: laptop
+      - const: convertible
+      - const: server
+      - const: tablet
+      - const: handset
+      - const: watch
+      - const: embedded
+    maxItems: 1
   "#address-cells":
     enum: [1, 2]
   "#size-cells":
@@ -63,6 +74,7 @@ examples:
     / {
         compatible = "acme,boogieboard";
         model = "Acme Ltd. Boogieboard developer system";
+        chassis-type = "embedded";
         #address-cells = <1>;
         #size-cells = <1>;
         memory@0 {


### PR DESCRIPTION
This patch adds an optional 'chassis-type' property to the root node in order to specify the device form factor, mimicking what is already available through DMI on ACPI-based systems.

Such information can be useful (for example, in order to implement different behavior on a desktop and on a smartphone) but is not currently available on DT-based systems.

Possible values are identical to those used by systemd's [hostnamed](https://www.freedesktop.org/software/systemd/man/machine-info.html#CHASSIS=).

Related specification proposal: https://github.com/devicetree-org/devicetree-specification/pull/45