### PR TITLE
schemas: cpus: document CPU-specific "status" property

### DIFF
--- a/schemas/cpus.yaml
+++ b/schemas/cpus.yaml
@@ -73,6 +73,14 @@ patternProperties:
           Specifies the current frequency at which the timebase and the
           decrementer registers are updated (in Hertz).
 
+      status:
+        $ref: "types.yaml#/definitions/string"
+        enum: [ okay, disabled, fail ]
+        description:
+          A standard property describing the state of a CPU. A CPU may be
+          running ("okay"), in a quiescent state ("disabled") or be not
+          operational or not exist ("fail").
+
       enable-method:
         $ref: /schemas/types.yaml#/definitions/string-array
         description:


### PR DESCRIPTION
As discussed in [1] and [2], CPU nodes have an unusual interpretation of
the "disabled" status. Explicitly document the okay, disabled and fail
status values in cpus.yaml.

[1] https://www.lkml.org/lkml/2020/8/26/1237
[2] https://www.spinics.net/lists/devicetree-spec/msg01007.html

Signed-off-by: Matthias Schiffer <matthias.schiffer@ew.tq-group.com>

I wasn't able to actually verify anything against this schema. It seems that the "status" property has some special behaviour that makes unknown values pass validation?