### PR TITLE
schemas: pci: Add EP regulator supply properties

### DIFF
--- a/schemas/pci/pci-bus.yaml
+++ b/schemas/pci/pci-bus.yaml
@@ -143,6 +143,12 @@ patternProperties:
           maxItems: 5
         minItems: 1
         maxItems: 6   # Up to 6 BARs
+      vpcie12v-supply:
+        description: 12v regulator phandle for the endpoint device
+      vpcie3v3-supply:
+        description: 3.3v regulator phandle for the endpoint device
+      vpcie3v3aux-supply:
+        description: 3.3v AUX regulator phandle for the endpoint device
     required:
       - reg
 


### PR DESCRIPTION
Add three standard PCIe voltage regulators as properties: vpcie3v3,
vpcie3v3aux, and vpcie12v.