### PR TITLE
schemas: pci: Move PCIe parts to pcie-bus.yaml

### DIFF
--- a/schemas/pci/pci-bus.yaml
+++ b/schemas/pci/pci-bus.yaml
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: (GPL2.0-only OR BSD-2-Clause)
 # Copyright 2018 Linaro Ltd.
+# Copyright 2021 Pali Rohár <pali@kernel.org>
 %YAML 1.2
 ---
 $id: http://devicetree.org/schemas/pci/pci-bus.yaml#
@@ -10,7 +11,7 @@ title: PCI bus schema
 description: |
   Common properties for PCI host bridge nodes and PCI bus structure.
 
-  PCI bus bridges have standardized Device Tree bindings:
+  PCI bus, child and function nodes have standardized Device Tree bindings:
 
   PCI Bus Binding to: IEEE Std 1275-1994
   http://www.devicetree.org/open-firmware/bindings/pci/pci2_1.pdf
@@ -22,139 +23,202 @@ description: |
 
 maintainers:
   - Rob Herring <robh@kernel.org>
+  - Pali Rohár <pali@kernel.org>
 
-properties:
-  $nodename:
-    pattern: "^pcie?@"
+$defs:
+  pci-function:
+    title: PCI function (part of PCI device)
 
-  ranges:
-    oneOf:
-      - $ref: "/schemas/types.yaml#/definitions/flag"
-      - minItems: 1
-        maxItems: 32    # Should be enough
-        items:
-          minItems: 5
-          maxItems: 7
-          additionalItems: true
-          items:
-            - enum:
-                - 0x01000000
-                - 0x02000000
-                - 0x03000000
-                - 0x42000000
-                - 0x43000000
-                - 0x81000000
-                - 0x82000000
-                - 0x83000000
-                - 0xc2000000
-                - 0xc3000000
+    description: |
+      One of a number of logically-independent parts of a PCI device.
+      Many PCI devices have only one function per device.
 
-  dma-ranges:
-    oneOf:
-      - type: boolean
-      - minItems: 1
-        maxItems: 32    # Should be enough
-        items:
-          minItems: 5
-          maxItems: 7
-          additionalItems: true
-          items:
-            - enum:
-                - 0x02000000
-                - 0x03000000
-                - 0x42000000
-                - 0x43000000
-
-  "#address-cells":
-    const: 3
-
-  "#size-cells":
-    const: 2
-
-  device_type:
-    const: pci
-
-  bus-range:
-    $ref: /schemas/types.yaml#/definitions/uint32-array
-    minItems: 2
-    maxItems: 2
-    items:
-      maximum: 255
-
-  "#interrupt-cells":
-    const: 1
-
-  interrupt-map: true
-#    minItems: 1
-#    maxItems: 88    # 22 IDSEL x 4 IRQs
-#    items:
-#      minItems: 6   # 3 addr cells, 1 PCI IRQ cell, 1 phandle, 1+ parent addr and IRQ cells
-#      maxItems: 16
-
-  interrupt-map-mask:
-    items:
-      - description: PCI high address cell
-        minimum: 0
-        maximum: 0xf800
-      - description: PCI mid address cell
-        const: 0
-      - description: PCI low address cell
-        const: 0
-      - description: PCI IRQ cell
-        minimum: 0
-        maximum: 7
-
-  linux,pci-domain:
-    $ref: /schemas/types.yaml#/definitions/uint32
-
-  max-link-speed:
-    $ref: /schemas/types.yaml#/definitions/uint32
-    enum: [ 1, 2, 3, 4 ]
-
-  num-lanes:
-    description: The number of PCIe lanes
-    $ref: /schemas/types.yaml#/definitions/uint32
-    enum: [ 1, 2, 4, 8, 16, 32 ]
-
-  reset-gpios:
-    description: GPIO controlled connection to PERST# signal
-    maxItems: 1
-
-  supports-clkreq:
-    type: boolean
-
-  aspm-no-l0s:
-    description: Disables ASPM L0s capability
-    type: boolean
-
-  vendor-id:
-    description: The PCI vendor ID
-    $ref: /schemas/types.yaml#/definitions/uint32
-
-  device-id:
-    description: The PCI device ID
-    $ref: /schemas/types.yaml#/definitions/uint32
-
-patternProperties:
-  "^[a-zA-Z][a-zA-Z0-9,+\\-._]{0,63}@1?[0-9a-f](,[0-7])?$":
-    type: object
     properties:
+      $nodename:
+        pattern: "^[a-zA-Z][a-zA-Z0-9,+\\-._]{0,63}@1?[0-9a-f](,[0-7])?$"
+
       compatible:
         contains:
           pattern: "^(pci[0-9a-f]{3,4},[0-9a-f]{1,4}|pciclass,[0-9a-f]{4,6})$"
+
+      device_type:
+        const: pci
+
       reg:
         items:
           minItems: 5
           maxItems: 5
         minItems: 1
         maxItems: 6   # Up to 6 BARs
+
+      vendor-id:
+        description: The PCI vendor ID
+        $ref: /schemas/types.yaml#/definitions/uint32
+
+      device-id:
+        description: The PCI device ID
+        $ref: /schemas/types.yaml#/definitions/uint32
+
     required:
+      - device_type
       - reg
 
-required:
-  - device_type
-  - ranges
-  - "#address-cells"
-  - "#size-cells"
+
+  pci-bridge:
+    title: PCI-to-PCI bridge function
+
+    description: |
+      A hardware device that is, from an electrical standpoint, a single
+      PCI function on one PCI bus (the "parent" bus) and the bus controller
+      of a secondary PCI bus (the "child" bus).
+
+    allOf:
+      - $ref: "#/$defs/pci-child-bus"
+      - $ref: "#/$defs/pci-function"
+      - properties:
+          compatible:
+            contains:
+              const: "pciclass,0604"
+          reg:
+            maxItems: 2   # PCI-to-PCI bridge can have up to 2 BARs
+
+
+  pci-child-bus:
+    title: PCI child bus node
+
+    description: |
+      Node which represents segment of PCI bus. For PCI-to-PCI bridge it is
+      secondary bus. Subnodes of this node represents of PCI functions.
+
+    properties:
+      device_type:
+        const: pci
+
+      bus-range:
+        $ref: /schemas/types.yaml#/definitions/uint32-array
+        minItems: 2
+        maxItems: 2
+        items:
+          maximum: 255
+
+      "#interrupt-cells":
+        const: 1
+
+      interrupt-map: true
+#        minItems: 1
+#        maxItems: 88    # 22 IDSEL x 4 IRQs
+#        items:
+#          minItems: 6   # 3 addr cells, 1 PCI IRQ cell, 1 phandle, 1+ parent addr and IRQ cells
+#          maxItems: 16
+
+      interrupt-map-mask:
+        items:
+          - description: PCI high address cell
+            minimum: 0
+            maximum: 0xf800
+          - description: PCI mid address cell
+            const: 0
+          - description: PCI low address cell
+            const: 0
+          - description: PCI IRQ cell
+            minimum: 0
+            maximum: 7
+
+    patternProperties:
+      ".*":
+        allOf:
+          - if:
+              type: object
+              properties:
+                device_type:
+                  const: pci
+            then:
+              allOf:
+                - $ref: "#/$defs/pci-function"
+              properties:
+                $nodename:
+                  pattern: "^[a-zA-Z][a-zA-Z0-9,+\\-._]{0,63}@1?[0-9a-f](,[0-7])?$"
+          - if:
+              type: object
+              properties:
+                compatible:
+                  contains:
+                    const: "pciclass,0604"
+            then:
+              $ref: "#/$defs/pci-bridge"
+
+      "@1?[0-9a-f](,[0-7])?$":
+        $ref: "#/$defs/pci-function"
+
+    required:
+      - device_type
+
+
+  pci-master-bus:
+    title: PCI master bus node
+
+    description: |
+      Node which represents PCI host bridge, root of the PCI bus segment group.
+      Subnodes represents top level PCI functions.
+
+    allOf:
+      - $ref: "#/$defs/pci-child-bus"
+
+    properties:
+      ranges:
+        oneOf:
+          - $ref: /schemas/types.yaml#/definitions/flag
+          - minItems: 1
+            maxItems: 32    # Should be enough
+            items:
+              minItems: 5
+              maxItems: 7
+              additionalItems: true
+              items:
+                - enum:
+                    - 0x01000000
+                    - 0x02000000
+                    - 0x03000000
+                    - 0x42000000
+                    - 0x43000000
+                    - 0x81000000
+                    - 0x82000000
+                    - 0x83000000
+                    - 0xc2000000
+                    - 0xc3000000
+
+      dma-ranges:
+        oneOf:
+          - type: boolean
+          - minItems: 1
+            maxItems: 32    # Should be enough
+            items:
+              minItems: 5
+              maxItems: 7
+              additionalItems: true
+              items:
+                - enum:
+                    - 0x02000000
+                    - 0x03000000
+                    - 0x42000000
+                    - 0x43000000
+
+      "#address-cells":
+        const: 3
+
+      "#size-cells":
+        const: 2
+
+      linux,pci-domain:
+        $ref: /schemas/types.yaml#/definitions/uint32
+
+    required:
+      - ranges
+      - "#address-cells"
+      - "#size-cells"
+
+
+allOf:
+  - $ref: "#/$defs/pci-master-bus"
 
 additionalProperties: true

--- a/schemas/pci/pcie-bus.yaml
+++ b/schemas/pci/pcie-bus.yaml
@@ -1,0 +1,190 @@
+# SPDX-License-Identifier: (GPL2.0-only OR BSD-2-Clause)
+# Copyright 2018 Linaro Ltd.
+# Copyright 2021 Pali Rohár <pali@kernel.org>
+%YAML 1.2
+---
+$id: http://devicetree.org/schemas/pci/pcie-bus.yaml#
+$schema: http://devicetree.org/meta-schemas/base.yaml#
+
+title: PCIe controller schema
+
+description: |
+  Common properties for PCIe segment group which consist of PCIe host bridge
+  node, PCIe Root Port nodes, PCIe switch nodes and PCIe endpoint nodes.
+
+maintainers:
+  - Rob Herring <robh@kernel.org>
+  - Pali Rohár <pali@kernel.org>
+
+$defs:
+  pcie-downstream-port:
+    title: PCI Express Downstream port
+
+    description: |
+      This node represents PCI Express port in Downstream direction of some PCI
+      Bridge compatible function together with PCI secondary bus of that bridge.
+      For example it can be PCI Express Root port, or Downstream port of PCI
+      Express Switch, or PCI Express port of PCI/X to PCI Express (reverse)
+      bridge. This node contains also PCI Express link and slot properties for
+      downstream direction.
+
+    allOf:
+      - $ref: /schemas/pci/pci-bus.yaml#/$defs/pci-bridge
+
+    $nodename:
+      pattern: "@1?[0-9a-f](,0)?$"
+
+    max-link-speed:
+      $ref: /schemas/types.yaml#/definitions/uint32
+      enum: [ 1, 2, 3, 4 ]
+
+    num-lanes:
+      description: The number of PCIe lanes
+      $ref: /schemas/types.yaml#/definitions/uint32
+      enum: [ 1, 2, 4, 8, 16, 32 ]
+
+    reset-gpios:
+      description: GPIO controlled connection to PERST# signal
+      maxItems: 1
+
+    supports-clkreq:
+      type: boolean
+
+    aspm-no-l0s:
+      description: Disables ASPM L0s capability
+      type: boolean
+
+    patternProperties:
+      ".*":
+        if:
+          type: object
+          properties:
+            device_type:
+              const: pci
+        then:
+          oneOf:
+            - $ref: "#/$defs/pcie-endpoint-function"
+            - $ref: "#/$defs/pcie-switch"
+
+      "@1?[0-9a-f](,[0-7])?$":
+        oneOf:
+          - $ref: "#/$defs/pcie-endpoint-function"
+          - $ref: "#/$defs/pcie-switch"
+
+
+  pcie-upstream-port:
+    title: PCI Express Upstream port
+
+    description: |
+      This node represents PCI Express port in Upstream direction of some PCI
+      Bridge compatible function together with PCI secondary bus of that bridge.
+      For example it can be Upstream port of PCI Express Switch or PCI Express
+      port of PCI Express to PCI/X bridge.
+
+    allOf:
+      - $ref: /schemas/pci/pci-bus.yaml#/$defs/pci-bridge
+
+    $nodename:
+      pattern: "@1?[0-9a-f](,0)?$"
+
+
+  pcie-root-port:
+    title: PCI Express Root port
+
+    description: |
+      This node represents PCI Express Root port, special case of PCI Express
+      port in Downstream direction, which is part of PCI Express Root Complex.
+
+    allOf:
+      - $ref: "#/$defs/pcie-downstream-port"
+
+
+  pcie-switch:
+    title: PCI Express switch
+
+    description: |
+      This node represents PCI Express switch device, which top level part is
+      PCI Express port in Upstream direction and subnodes are PCI Express ports
+      in Downstream direction.
+
+    allOf:
+      - $ref: "#/$defs/pcie-upstream-port"
+
+    $nodename:
+      pattern: "^pcie-switch@0(,[0-7])?$"
+
+    patternProperties:
+      ".*":
+        if:
+          type: object
+          properties:
+            device_type:
+              const: pci
+        then:
+          allOf:
+            - $ref: "#/$defs/pcie-downstream-port"
+          properties:
+            $nodename:
+              pattern: "^pcie-port@1?[0-9a-f](,0)?$"
+
+      "@1?[0-9a-f](,[0-7])?$":
+        $ref: "#/$defs/pcie-downstream-port"
+
+
+  pcie-endpoint-function:
+    title: PCI Express endpoint function
+
+    description: |
+      This node represents non-bridge PCI Express endpoint function which has
+      upstream direction. This node is what represents single-function PCI
+      Express expansion card.
+
+    allOf:
+      - $ref: /schemas/pci/pci-bus.yaml#/$defs/pci-function
+      - not:
+          properties:
+            compatible:
+              contains:
+                const: "pciclass,0604"
+
+    $nodename:
+      pattern: "@0(,[0-7])?$"
+
+
+  pcie-controller:
+    title: PCI Express controller
+
+    description: |
+      This node represents PCI Express controller, also known as PCI Host bridge
+      which is root of the PCI bus segment group, called also Linux PCI domain.
+      It is PCI master bus and is part of the PCI Express Root Complex block.
+
+    allOf:
+      - $ref: /schemas/pci/pci-bus.yaml#
+
+    properties:
+      $nodename:
+        pattern: "^pcie@"
+
+    patternProperties:
+      ".*":
+        if:
+          type: object
+          properties:
+            device_type:
+              const: pci
+        then:
+          allOf:
+            - $ref: "#/$defs/pcie-root-port"
+          properties:
+            $nodename:
+              patttern: "^pcie-root-port@1?[0-9a-f](,0)?$"
+
+      "@1?[0-9a-f](,[0-7])?$":
+        $ref: "#/$defs/pcie-root-port"
+
+
+allOf:
+  - $ref: "#/$defs/pcie-controller"
+
+additionalProperties: true


### PR DESCRIPTION
We need to distinguish PCI and PCIe buses. Also we need to distinguish
between different PCIe devices to allow specifying properties which are
valid only for some of them. Mixing all these things together is really bad
idea.

Add definitions for PCIe Host Bridges, PCIe Root Ports, PCIe switches,
PCIe endpoints in new pcie-bus.yaml schema. Move all PCIe properties from
pci-bus.yaml schema into correct PCIe nodes.

Original pci-bus.yaml now contains only PCI properties. It has
additionalProperties set to true, to allow specifying previous old
PCIe properties in PCI nodes.