### PR TITLE
schemas: core: Add 'label' property

### DIFF
--- a/schemas/dt-core.yaml
+++ b/schemas/dt-core.yaml
@@ -21,6 +21,8 @@ properties:
     $ref: "types.yaml#/definitions/string-array"
     items:
       pattern: "^[a-zA-Z][a-zA-Z0-9,+\\-._]+$"
+  label:
+    $ref: "types.yaml#/definitions/string"
   dma-coherent:
     $ref: "types.yaml#/definitions/flag"
   dma-ranges:


### PR DESCRIPTION
Support a 'label' property on all device nodes.

This property is useful to be able to identify an individual device when multiple individual ones are present in the system.

Note that this is already supported (but not documented) by the IIO subsystem on Linux.

I wonder if this property should be usable everywhere by default, without requiring the specific device shemas to add `label: true`?