### PR TITLE
schemas: pci-bus: Add 'slot-power-limit-milliwatt' property

### DIFF
--- a/schemas/pci/pci-bus.yaml
+++ b/schemas/pci/pci-bus.yaml
@@ -122,6 +122,12 @@ properties:
     description: GPIO controlled connection to PERST# signal
     maxItems: 1
 
+  slot-power-limit-milliwatt:
+    description:
+      If present, specifies slot power limit in milliwatts.
+      This property is invalid in host bridge nodes.
+    maxItems: 1
+
   supports-clkreq:
     type: boolean
 

--- a/schemas/property-units.yaml
+++ b/schemas/property-units.yaml
@@ -76,6 +76,12 @@ patternProperties:
   "-micro-ohms$":
     $ref: "types.yaml#/definitions/uint32-array"
     description: microohm
+  "-microwatt$":
+    $ref: "types.yaml#/definitions/uint32-array"
+    description: microwatt
+  "-milliwatt$":
+    $ref: "types.yaml#/definitions/uint32-array"
+    description: milliwatt
   "-microwatt-hours$":
     $ref: "types.yaml#/definitions/uint32-array"
     description: microwatt hour


### PR DESCRIPTION
Add 'slot-power-limit-milliwatt' property that specifies slot power
limit, which is a form-factor and board specific value and must be
initialized by hardware.

Some PCIe controllers delegate this work to software to allow hardware
flexibility and therefore this property basically specifies what should
host bridge program into PCIe Slot Capabilities registers.

The property needs to be specified in milliwatts unit instead of the
special format defined by Slot Capabilities register (which encodes
scaling factor or different unit). Host drivers should convert the value
from milliwatts to the needed format.

Signed-off-by: Pali Rohár <pali@kernel.org>
Signed-off-by: Marek Behún <marek.behun@nic.cz>