### PR TITLE
schemas: chosen: Add 'u-boot,bootconf' node

### DIFF
--- a/dtschema/schemas/chosen.yaml
+++ b/dtschema/schemas/chosen.yaml
@@ -200,6 +200,12 @@ properties:
       carrying the IMA measurement logs. The address and the suze are expressed in
       #address-cells and #size-cells, respectively of the root node.
 
+  u-boot,bootconf:
+    $ref: types.yaml#/definitions/string
+    description:
+      This property can be used by U-Boot to pass the selected configuration unit
+      name of the booted image down to the operating system.
+
 patternProperties:
   "^framebuffer": true
 


### PR DESCRIPTION
Add string property allowing to pass down the name of the selected
image configuration node of a uImage.FIT to the operating system.

Signed-off-by: Daniel Golle <daniel@makrotopia.org>

Suggested and discussed also on the U-Boot Mailing List <u-boot@lists.denx.de>
https://patchwork.ozlabs.org/project/uboot/patch/YjkIr8wmz1XEOVNh@makrotopia.org/

If this generally sounds acceptable, I will send a v2 to the U-Boot Mailing List with the property now being called `u-boot,bootconf` as suggested here (originally I simply named it `bootconf`)