### PR TITLE
schemas: i2c-controller: Add 'no-detect' property

### DIFF
--- a/dtschema/schemas/i2c/i2c-controller.yaml
+++ b/dtschema/schemas/i2c/i2c-controller.yaml
@@ -28,6 +28,12 @@ properties:
     minimum: 1000
     maximum: 3000000
 
+  no-detect:
+    type: boolean
+    description:
+      States that no other devices are present on this bus other than the ones
+      listed in the devicetree.
+
 patternProperties:
   '@[0-9a-f]+$':
     type: object


### PR DESCRIPTION
In some cases, operating systems may attempt to detect the presence of
devices on an I2C bus by, for example, attempting to read specific
registers from a list of addresses which some common peripherals is
known to use.

Add a property which can be used to indicate that there are no devices
on the bus except the ones listed in the devicetree, thus allowing
operating systems to choose to avoid spending time on attempting this
kind of detection of devices which do not exist.

Signed-off-by: Vincent Whitchurch <vincent.whitchurch@axis.com>