### PR TITLE
dtschema: Add basis points property unity

### DIFF
--- a/dtschema/schemas/property-units.yaml
+++ b/dtschema/schemas/property-units.yaml
@@ -35,6 +35,10 @@ patternProperties:
     $ref: "types.yaml#/definitions/uint32-array"
     description: percentage
 
+  "-bp$":
+    $ref: "types.yaml#/definitions/uint32-array"
+    description: basis points (1/100 of a percent)
+
   # Time/Frequency
   "-mhz$":
     $ref: "types.yaml#/definitions/uint32-array"


### PR DESCRIPTION
Document the basis points property unit: one hundredth of 1 percentage
point.  The unit is not very popular but recently new bindings using it
were submitted.

See also: https://lore.kernel.org/all/1652282793-5580-2-git-send-email-quic_kriskura@quicinc.com/

Signed-off-by: Krzysztof Kozlowski <krzk@kernel.org>