### PR TITLE
schemas: i2c: Remove tabs from line 168

### DIFF
--- a/dtschema/schemas/i2c/i2c-controller.yaml
+++ b/dtschema/schemas/i2c/i2c-controller.yaml
@@ -165,7 +165,7 @@ patternProperties:
                 - wakeup
                 - smbus_alert
             description:
-              Names which are recognized by I2C core,	other names are	left to
+              Names which are recognized by I2C core, other names are left to
               individual bindings.
 
       wakeup-source:


### PR DESCRIPTION
These tabs prevent YAML from being loaded inside a python script with 
PyYAML.

Error "yaml.scanner.ScannerError: while scanning for the next token 
found character '\t' that cannot start any token"