### PR TITLE
schemas: chosen: Document the linux,tpm-kexec-buffer node

### DIFF
--- a/dtschema/schemas/chosen.yaml
+++ b/dtschema/schemas/chosen.yaml
@@ -187,7 +187,7 @@ properties:
     maxItems: 2
     description:
       This property(currently used by powerpc, arm64) holds the memory range,
-      "the address and the size", of the Integrity Measuremnet Architecture(IMA)
+      "the address and the size", of the Integrity Measurement Architecture(IMA)
       measurement logs that are being carried over to the new kernel.
 
       / {
@@ -197,7 +197,7 @@ properties:
         };
 
       This property does not represent real hardware, but the memory allocated for
-      carrying the IMA measurement logs. The address and the suze are expressed in
+      carrying the IMA measurement logs. The address and the size are expressed in
       #address-cells and #size-cells, respectively of the root node.
 
   u-boot,bootconf:

--- a/dtschema/schemas/chosen.yaml
+++ b/dtschema/schemas/chosen.yaml
@@ -200,6 +200,24 @@ properties:
       carrying the IMA measurement logs. The address and the size are expressed in
       #address-cells and #size-cells, respectively of the root node.
 
+  linux,tpm-kexec-buffer:
+    $ref: types.yaml#definitions/uint64-array
+    maxItems: 2
+    description:
+      This property (currently used by powerpc64) holds the memory range,
+      "the address and the size", of the TPM's measurement log that is being
+      carried over to the new kernel.
+
+      / {
+          chosen {
+              linux,tpm-kexec-buffer = <0x9 0x82000000 0x0 0x00008000>;
+                  };
+        };
+
+      This property does not represent real hardware, but the memory allocated for
+      carrying the TPM measurement log. The address and the size are expressed in
+      #address-cells and #size-cells, respectively of the root node.
+
   u-boot,bootconf:
     $ref: types.yaml#/definitions/string
     description:


### PR DESCRIPTION
This PR goes along with the recently sent patches for support of carrying the TPM measurement log across a kexec.
