### PR TITLE
schemas: add dma-noncoherent property

### DIFF
--- a/dtschema/schemas/dt-core.yaml
+++ b/dtschema/schemas/dt-core.yaml
@@ -25,6 +25,8 @@ properties:
     $ref: "types.yaml#/definitions/string"
   dma-coherent:
     $ref: "types.yaml#/definitions/flag"
+  dma-noncoherent:
+    $ref: "types.yaml#/definitions/flag"
   dma-ranges:
     oneOf:
       - $ref: "types.yaml#/definitions/flag"


### PR DESCRIPTION
When using dma-coherent, the assumption is that the system is noncoherent
in general with specific devices being coherent.

Similarly there can be systems being coherent by default with specific
devices being noncoherent.

Add a 'dma-noncoherent' property to the schema which also got added to
the specification.

Signed-off-by: Heiko Stuebner <heiko@sntech.de>