### PR TITLE
dt-validate: if node is disabled, pass on any missing property

### DIFF
--- a/tools/dt-validate
+++ b/tools/dt-validate
@@ -60,10 +60,12 @@ class schema_group():
                             if 'required property' in error.message:
                                 continue
                             elif error.context:
+                                found = False
                                 for e in error.context:
-                                    if not 'required property' in e.message:
+                                    if 'required property' in e.message:
+                                        found = True
                                         break
-                                else:
+                                if found:
                                     continue
 
                         if schema['$id'] == 'generated-compatibles':


### PR DESCRIPTION
Validation of a node with with disabled nodes is failing, if the schema references multiple other schemas in oneOf.  For example:

```
  mdss {
    ...
    dsi-phy@... {
      ...
      // Some required property is missing
      status = "disabled";
    };
  };
```

and schema:

```
  properties:
    "^dsi-phy@[1-9a-f][0-9a-f]*$":
    type: object
    oneOf:
      - $ref: dsi-phy-14nm.yaml
      - $ref: dsi-phy-20nm.yaml
      - $ref: dsi-phy-28nm.yaml
```

The check_node() was ignoring errors for disabled nodes if they contained 'required property' in error message or all of sub-errors do not have such error.  Thus if any of referenced schemas failed with any other error, the entire check failed.

Rework check_node() so it will ignore errors for disabled nodes if any of messages contain 'required property'.

This might hide some useful errors, but only for disabled nodes which is not that important.

Signed-off-by: Krzysztof Kozlowski <krzk@kernel.org>