### PR TITLE
schemas: phy: Increase phy-type maximum

### DIFF
--- a/dtschema/schemas/phy/phy-provider.yaml
+++ b/dtschema/schemas/phy/phy-provider.yaml
@@ -23,7 +23,7 @@ properties:
       set in the PHY cells.
     $ref: /schemas/types.yaml#/definitions/uint32
     minimum: 1
-    maximum: 11
+    maximum: 13
 
 required:
   - "#phy-cells"


### PR DESCRIPTION
With the (pending) [addition of PHY_TYPE_2500BASEX and PHY_TYPE_10GBASER](https://lore.kernel.org/linux-phy/20220902213721.946138-2-sean.anderson@seco.com/), the maximum value for `phy-type` must also be increased.