### PR TITLE
schemas: qemu,platform: Add interrupt-parent property

### DIFF
--- a/dtschema/meta-schemas/interrupts.yaml
+++ b/dtschema/meta-schemas/interrupts.yaml
@@ -21,7 +21,6 @@ properties:
     oneOf:
       - $ref: "boolean.yaml"
       - $ref: "nodes.yaml"
-  interrupt-parent: false # interrupt-parent is implicit
 
 dependentRequired:
   interrupt-map: ['#interrupt-cells']

--- a/dtschema/schemas/bus/qemu,platform.yaml
+++ b/dtschema/schemas/bus/qemu,platform.yaml
@@ -39,6 +39,9 @@ properties:
       non-posted memory accesses (i.e. a non-posted mapping mode) for MMIO
       ranges.
 
+  interrupt-parent:
+    $ref: /schemas/types.yaml#/definitions/phandle
+
 patternProperties:
   # All other properties should be child nodes with unit-address and 'reg'
   "@(0|[1-9a-f][0-9a-f]*)$":


### PR DESCRIPTION
The device-tree node for the qemu,plaform bus contains an interrupt-parent property, even though only the bus' children generate interrupts. According to the specification v0.3, the interrupt-parent property should only be on devices generating interrupts:

  Nodes that represent interrupt-generating devices contain an
  interrupt-parent property which has a phandle value that points to the
  device to which the device’s interrupts are routed, typically an
  interrupt controller. If an interrupt-generating device does not have
  an interrupt-parent property, its interrupt parent is assumed to be
  its devicetree parent.

However, the interrupt-parent property is commonly found in root and intermediate bus nodes so this case is de facto valid [1]. Add the interrupt-parent property to the schema.

Unfortunately this requires removing the current rule for interrupt-parent, otherwise it produces a syntax error ("qemu,platform.yaml: ignoring, error in schema: properties: interrupt-parent" "False schema does not allow {'$ref': '/schemas/types.yaml#/definitions/phandle'}")

[1] https://www.spinics.net/lists/devicetree-spec/msg00839.html

Signed-off-by: Jean-Philippe Brucker <jean-philippe@linaro.org>