### PR TITLE
schemas: phy: Once again increase phy-type maximum

### DIFF
--- a/dtschema/schemas/phy/phy-provider.yaml
+++ b/dtschema/schemas/phy/phy-provider.yaml
@@ -23,7 +23,7 @@ properties:
       set in the PHY cells.
     $ref: /schemas/types.yaml#/definitions/uint32
     minimum: 1
-    maximum: 13
+    maximum: 32
 
 required:
   - "#phy-cells"


### PR DESCRIPTION
With the combination of [PHY_TYPE_USXGMII](https://lore.kernel.org/r/20220628122255.24265-3-rogerq@kernel.org) and (soon to be resent) [PHY_TYPE_2500BASEX and PHY_TYPE_10GBASER](https://lore.kernel.org/linux-phy/20220902213721.946138-2-sean.anderson@seco.com/), the maximum value for phy-type must be increased to 14.