### PR TITLE
Revert "Partially Revert "dtschema: add nanoamp unit""

### DIFF
--- a/dtschema/meta-schemas/core.yaml
+++ b/dtschema/meta-schemas/core.yaml
@@ -58,7 +58,7 @@ definitions:
         propertyNames:
           enum: [ description, deprecated ]
 
-      '-(bits|-kBps|percent|bp|mhz|hz|sec|ms|us|ns|ps|mm|microamp(-hours)?|(micro-)?ohms|microwatt-hours|microvolt|(femto|pico)farads|(milli)?celsius|kelvin|kpascal)$':
+      '-(bits|-kBps|percent|bp|mhz|hz|sec|ms|us|ns|ps|mm|nanoamp|microamp(-hours)?|(micro-)?ohms|microwatt-hours|microvolt|(femto|pico)farads|(milli)?celsius|kelvin|kpascal)$':
         allOf:
           - $ref: "cell.yaml#/array"
           - description: Standard unit suffix properties don't need a type $ref


### PR DESCRIPTION
A patch has been sent upstream to remove the $ref from -nanoamp properties.

This reverts commit f5f03f655760e165c250aceac829fc3c4eddd43f.