### PR TITLE
schemas: relax phy-cells requirement for PHY-like nodes

### DIFF
--- a/dtschema/schemas/phy/phy-provider.yaml
+++ b/dtschema/schemas/phy/phy-provider.yaml
@@ -8,9 +8,11 @@ title: PHY Provider Common Properties
 maintainers:
   - Rob Herring <robh@kernel.org>
 
+# always select the core schema
+select: true
+
 properties:
-  $nodename:
-    pattern: "^(|usb-|usb2-|usb3-|pci-|pcie-|sata-)phy(@[0-9a-f,]+)*$"
+  # Recommended node names: (|usb-|usb2-|usb3-|pci-|pcie-|sata-)phy
 
   "#phy-cells": true
 
@@ -24,9 +26,6 @@ properties:
     $ref: /schemas/types.yaml#/definitions/uint32
     minimum: 1
     maximum: 32
-
-required:
-  - "#phy-cells"
 
 dependentRequired:
   phy-type: [ '#phy-cells' ]


### PR DESCRIPTION
Several Devicetree nodes in Linux kernel are named "phy", but they do not have "#phy-cells" property.  Instead their children have it.  This leads to a lot of false positives, so relax the requirement and do not enforce having #phy-cells for every "phy" node.

Fixes: #22 

Signed-off-by: Krzysztof Kozlowski <krzk@kernel.org>