### PR TITLE
dtschema: add qcom,board-id to variable sized matrix property list

### DIFF
--- a/dtschema/lib.py
+++ b/dtschema/lib.py
@@ -217,6 +217,7 @@ def _is_matrix_schema(subschema):
 
 known_variable_matrix_props = {
     'fsl,pins',
+    'qcom,board-id',
 }
 
 


### PR DESCRIPTION
Qualcomm DTS come with:

  qcom,board-id = <8 3005>;
  qcom,board-id = <8 0 16859 23>;
  qcom,board-id = <8 0 15801 15>, <8 0 15801 16>;

Signed-off-by: Krzysztof Kozlowski <krzk@kernel.org>