### PR TITLE
meta-schemas: cell: Add quotation marks

### DIFF
--- a/dtschema/meta-schemas/cell.yaml
+++ b/dtschema/meta-schemas/cell.yaml
@@ -75,7 +75,7 @@ single:
     default:
       type: integer
     oneOf:
-      $ref: #/single
+      $ref: '#/single'
 
   propertyNames:
     enum: [ description, deprecated, const, enum, minimum, maximum, multipleOf, default, $ref, oneOf ]


### PR DESCRIPTION
YAML syntax treats # sign with leading space as a comment. Fix it by placing quotation mark around it.

Signed-off-by: Michał Grzelak <mchl.grzlk@gmail.com>