### PR TITLE
schemas: bootph: Add check for bootph tags in parent nodes

### DIFF
--- a/dtschema/schemas/bootph.yaml
+++ b/dtschema/schemas/bootph.yaml
@@ -85,4 +85,23 @@ properties:
     description:
       Include this node in all phases (for U-Boot see enum u_boot_phase).
 
+allOf:
+  - if:
+      anyOf:
+        - required: [ bootph-pre-sram ]
+        - required: [ bootph-verify ]
+        - required: [ bootph-pre-ram ]
+        - required: [ bootph-some-ram ]
+        - required: [ bootph-all ]
+    then:
+      description: Parent nodes don't need bootph tags
+      patternProperties:
+        '.*':
+          properties:
+            bootph-pre-sram: false
+            bootph-verify: false
+            bootph-pre-ram: false
+            bootph-some-ram: false
+            bootph-all: false
+
 additionalProperties: true


### PR DESCRIPTION
When a node has boot phase tags, the parent node is implicitly included and a bootph tag is not needed. Add a schema to check for and disallow bootph tags in both parent and child nodes. It's not the greatest logic and resulting error message, but that's what works for json-schema.