### PR TITLE
schemas: i2c: Add the clock stretching property

### DIFF
--- a/dtschema/schemas/i2c/i2c-controller.yaml
+++ b/dtschema/schemas/i2c/i2c-controller.yaml
@@ -44,6 +44,18 @@ properties:
       Number of nanoseconds the SCL signal takes to rise; t(r) in the I2C
       specification.
 
+  i2c-scl-clk-low-timeout-ms:
+    description:
+      Number of miliseconds the clock line needs to be pulled down in order
+      to force a waiting state.
+
+  i2c-scl-has-clk-low-timeout:
+    type: boolean
+    description:
+      Indicates whether the controller implements the feature of wait
+      induction through SCL low, with the timeout being implemented
+      internally by the controller.
+
   i2c-sda-falling-time-ns:
     description:
       Number of nanoseconds the SDA signal takes to fall; t(f) in the I2C
@@ -120,6 +132,12 @@ properties:
     description:
       States that no other devices are present on this bus other than the ones
       listed in the devicetree.
+
+allOf:
+  - not:
+      required:
+        - i2c-scl-clk-low-timeout-ms
+        - i2c-scl-has-clk-low-timeout
 
 patternProperties:
   '@[0-9a-f]+$':


### PR DESCRIPTION
The I2C specification allows for the clock line to be held low for a specified timeout to force the slave device into a 'wait' mode. This feature is known as 'Clock stretching' and is optional.

In the NXP I2C specification, clock stretching is described as the process of pausing a transaction by holding the SCL line LOW. The transaction can only continue when the line is released HIGH again.[*] However, most target devices do not include an SCL driver and are therefore unable to stretch the clock.

Add the following properties:

 - i2c-scl-clk-low-timeout-ms: This property specifies the duration, in milliseconds, for which the clock is kept low and a client needs to detect a forced waiting state.

 - i2c-scl-has-clk-low-timeout: This property specifies whether the I2C controller implements the clock stretching property.

It's important to note that this feature should not be confused with the SMBUS clock timeout, which serves a similar function but specifies a timeout of 25-35ms. The I2C specification does not recommend any specific timeout.

[*] NXP, UM10204 - I2C-bus specification and user manual
    Rev. 7.0, 1 October 2021, chapter 3.1.9.