### PR TITLE
schemas: property-units: Allow negative values for % units

### DIFF
--- a/dtschema/schemas/property-units.yaml
+++ b/dtschema/schemas/property-units.yaml
@@ -38,11 +38,11 @@ patternProperties:
     description: kilobytes per second
 
   "-percent$":
-    $ref: types.yaml#/definitions/uint32-array
+    $ref: types.yaml#/definitions/int32-array
     description: percentage
 
   "-bp$":
-    $ref: types.yaml#/definitions/uint32-array
+    $ref: types.yaml#/definitions/int32-array
     description: basis points (1/100 of a percent)
 
   # Time/Frequency


### PR DESCRIPTION
Some hardware has negative percentage adjustments. Allow it.