### PR TITLE
meta-schemas: Allow '#' anywhere in required DT property names

### DIFF
--- a/dtschema/meta-schemas/keywords.yaml
+++ b/dtschema/meta-schemas/keywords.yaml
@@ -220,7 +220,7 @@ properties:
     type: array
     uniqueItems: true
     items:
-      pattern: '^([a-zA-Z#][a-zA-Z0-9,+\-._@]{0,63}|\$nodename)$'
+      pattern: '^([a-zA-Z#][a-zA-Z0-9#,+\-._@]{0,63}|\$nodename)$'
   select:
     $ref: "#/definitions/sub-schemas"
   then:

--- a/dtschema/schemas/dt-core.yaml
+++ b/dtschema/schemas/dt-core.yaml
@@ -74,7 +74,7 @@ patternProperties:
       - $ref: types.yaml#/definitions/phandle
 
   # property and node namespace overlaps. Catch both here
-  "^[a-zA-Z0-9][a-zA-Z0-9,+\\-._]{0,63}$":
+  "^[a-zA-Z0-9][a-zA-Z0-9#,+\\-._]{0,63}$":
     type: [object, array, boolean, 'null']
 
   # Anything with a '@' is definitely a node


### PR DESCRIPTION
Commit 0e28a44059a6 ("meta-schemas: Allow '#' anywhere is DT property names") amended the `propertyNames` regex to allow names such as `marvell,#interrupts`.

Make the same amendment to the `required` regex for consistency to avoid errors like:

```
  Documentation/devicetree/bindings/security/tpm/ibm,vtpm.yaml: required:4: 'ibm,#dma-address-cells' does not match '^([a-zA-Z#][a-zA-Z0-9,+\\-._@]{0,63}|\\$nodename)$'
  hint: 'required' must be valid DT property or node names
  from schema $id: http://devicetree.org/meta-schemas/keywords.yaml#
```