### PR TITLE
schemas: Add a schema for thermal consumer

### DIFF
--- a/dtschema/schemas/thermal/thermal.yaml
+++ b/dtschema/schemas/thermal/thermal.yaml
@@ -1,0 +1,34 @@
+# SPDX-License-Identifier: BSD-2-Clause
+# Copyright 2023 Collabora Ltd.
+%YAML 1.2
+---
+$id: http://devicetree.org/schemas/thermal/thermal.yaml#
+$schema: http://devicetree.org/meta-schemas/base.yaml#
+
+title: Thermal Consumer Common Properties
+
+maintainers:
+  - Rob Herring <robh@kernel.org>
+
+# always select the core schema
+select: true
+
+properties:
+  thermal-zones:
+    anyOf:
+      - type: object # for nodes named 'thermal-zones'
+      - $ref: /schemas/types.yaml#/definitions/phandle-array
+    description: List of thermal zone phandles, one for each
+      thermal zone input to the device.
+
+  thermal-zone-names:
+    $ref: /schemas/types.yaml#/definitions/string-array
+    description: List of thermal zone name strings sorted in the
+      same order as the thermal-zones property. Consumer drivers
+      will use thermal-zone-names to match thermal zone input
+      names with thermal zone specifiers.
+
+dependentRequired:
+  thermal-zone-names: [ thermal-zones ]
+
+additionalProperties: true


### PR DESCRIPTION
This adds a schema for thermal-zones consumers, useful for smart voltage scaling drivers that need to adjust CPU/GPU/other voltages based on chip quality and temperature of one or multiple zones, and for battery charge drivers that need to scale the charging current based on board dependant thermal zones readings (for example, battery temperature, device skin temperature, etc).

For more information, please look at https://lore.kernel.org/all/20231115144857.424005-1-angelogioacchino.delregno@collabora.com/

Cheers!
Angelo