### PR TITLE
Add the SI unit for pressure, with support for negative values

### DIFF
--- a/dtschema/schemas/property-units.yaml
+++ b/dtschema/schemas/property-units.yaml
@@ -124,8 +124,11 @@ patternProperties:
     description: SI unit of thermodynamic temperature
 
   # Pressure
+  "-pascal$":
+    $ref: types.yaml#/definitions/int32-array
+    description: pascal
   "-kpascal$":
-    $ref: types.yaml#/definitions/uint32-array
+    $ref: types.yaml#/definitions/int32-array
     description: kilopascal
 
 additionalProperties: true


### PR DESCRIPTION
Add the SI unit for pressure, with support for negative values.
Useful for sensors that detect small pressure differentials between
two ports.