### PR TITLE
RFC: schemas: memory: describe the Qualcomm ddr_device_type property

### DIFF
--- a/dtschema/schemas/memory.yaml
+++ b/dtschema/schemas/memory.yaml
@@ -49,6 +49,22 @@ patternProperties:
           can be corrected by the Error-Correction Code (ECC) memory subsystem
           (typically 0, 1 or 2).
 
+      ddr_device_type:
+        $ref: types.yaml#/definitions/uint32
+        deprecated: true
+        description:
+          This is the ugly non-standard property set by some bootloaders to
+          describe the attached memory type. Unfortunately it is not possible
+          to update those bootloaders to use the defined schema for LPDDR
+          device nodes. This property is described here solely for the
+          documentation purposes, it MUST NOT be used in any of the DT files.
+          Use of this property outside of the described usecase is strictly
+          forbidden.
+        enum:
+          - 5 # LPDDR3
+          - 7 # LPDDR4x
+          - 8 # LPDDR5
+
     required:
       - device_type
       - reg


### PR DESCRIPTION
The Qualcomm ABL bootloaders use the `ddr_device_type` property to describe the attached memory type.
We can not really change this bootloader on the end-user devices thanks to the SecureBoot. Certain drivers (display, GPU, video-encoding) need this information to properly program the hardware.
This PR attempts to document this property, while pointing out that its usage is limited to this particular bootloader, it should not be used by any other created designs and that its usage outside of the defined usecase is strictly forbidden.