### PR TITLE
dtb: expect nvmem-cell-cells

### DIFF
--- a/dtschema/dtb.py
+++ b/dtschema/dtb.py
@@ -272,7 +272,6 @@ phandle_args = {
     'msi-ranges': '#interrupt-cells',
     'gpio-ranges': 3,
 
-    'nvmem-cells': None,
     'memory-region': None,
 }
 


### PR DESCRIPTION
The 'nvmem-cells' has corresponding '#nvmem-cell-cells' property defining number cells, thus allow checks for phandle arguments.

Link: https://lore.kernel.org/linux-devicetree/20240109213739.558287-1-krzysztof.kozlowski@linaro.org/T/#u
Link: https://github.com/devicetree-org/dt-schema/pull/89