### PR TITLE
Fix SyntaxWarning: invalid escape sequence

### DIFF
--- a/dtschema/extract_example.py
+++ b/dtschema/extract_example.py
@@ -75,11 +75,11 @@ def main():
     if 'examples' in binding.keys():
         for idx, ex in enumerate(binding['examples']):
             # Check if example contains a root node "/{"
-            root_node = re.search('/\s*{', ex)
+            root_node = re.search(r'/\s*{', ex)
 
             if not root_node:
                 try:
-                    int_val = re.search('\sinterrupts\s*=\s*<([0-9a-zA-Z |()_]+)>', ex).group(1)
+                    int_val = re.search(r'\sinterrupts\s*=\s*<([0-9a-zA-Z |()_]+)>', ex).group(1)
                     int_val = re.sub(r'\(.+|\)', r'0', int_val)
                     int_cells = len(int_val.strip().split())
                 except:

--- a/dtschema/validator.py
+++ b/dtschema/validator.py
@@ -187,7 +187,7 @@ def get_prop_types(schemas):
     props = extract_types(schemas)
 
     # hack to remove aliases and generic patterns
-    del props['^[a-z][a-z0-9\-]*$']
+    del props[r'^[a-z][a-z0-9\-]*$']
 
     # Remove all node types
     for val in props.values():
@@ -221,11 +221,11 @@ def make_compatible_schema(schemas):
     # Allow 'foo' values for examples
     compat_sch += [{'pattern': '^foo'}]
 
-    prog = re.compile('.*[\^\[{\(\$].*')
+    prog = re.compile(r'.*[\^\[{\(\$].*')
     for c in compatible_list:
         if prog.match(c):
             # Exclude the generic pattern
-            if c != '^[a-zA-Z0-9][a-zA-Z0-9,+\-._/]+$' and \
+            if c != r'^[a-zA-Z0-9][a-zA-Z0-9,+\-._/]+$' and \
                not re.search(r'\.[+*]', c) and \
                c.startswith('^') and c.endswith('$'):
                 compat_sch += [{'pattern': c}]


### PR DESCRIPTION
This commit fixes the following warnings:

extract_example.py: SyntaxWarning: invalid escape sequence '\s'
  root_node = re.search('/\s*{', ex)
extract_example.py: SyntaxWarning: invalid escape sequence '\s'
  int_val = re.search('\sinterrupts\s*=\s*<([0-9a-zA-Z |()_]+)>', ex).group(1)
validator.py: SyntaxWarning: invalid escape sequence '\-'
  del props['^[a-z][a-z0-9\-]*$']
validator.py: SyntaxWarning: invalid escape sequence '\^'
  prog = re.compile('.*[\^\[{\(\$].*')
validator.py: SyntaxWarning: invalid escape sequence '\-'
  if c != '^[a-zA-Z0-9][a-zA-Z0-9,+\-._/]+$':