### PR TITLE
schemas: pci: bridge: Document WAKE# interrupt properties

### DIFF
--- a/dtschema/schemas/pci/pci-pci-bridge.yaml
+++ b/dtschema/schemas/pci/pci-pci-bridge.yaml
@@ -34,4 +34,10 @@ properties:
       to D3 states.
     type: boolean
 
+  interrupts:
+    description: wakeup interrupt
+
+  interrupt-names:
+    const: wake
+
 unevaluatedProperties: false


### PR DESCRIPTION
WAKE# sideband interrupt is used by the PCIe devices to signal the host to re-establish power and reference clocks while waking from D3Cold/L2 state.

This is based on the DT bindings patch proposed to LKML: https://lore.kernel.org/linux-pci/20230208111645.3863534-2-mmaddireddy@nvidia.com/

In that patch, there were 2 interrupts mentioned: "wake" and "pci", and the latter one was described as "legacy PCI interrupt". But those legacy interrupts are already defined as "INT-{A,B,C,D}" in pci-device.yaml. So I removed that one and just kept "wake".