### PR TITLE
schemas: pci: bridge: Document "supports-d3" property

### DIFF
--- a/dtschema/schemas/pci/pci-pci-bridge.yaml
+++ b/dtschema/schemas/pci/pci-pci-bridge.yaml
@@ -28,4 +28,10 @@ properties:
     contains:
       const: pciclass,0604
 
+  supports-d3:
+    description:
+      If present, this property specifies that the bridge supports transitioning
+      to D3 states.
+    type: boolean
+
 unevaluatedProperties: false


### PR DESCRIPTION
There is no standard way to detect the D3 support of the PCI-PCI bridges. So let's add a new property, "supports-d3" to specify that the bridge supports transitioning to D3 states.