### PR TITLE
schemas: Add -kbps and -mbps standard unit suffixes

### DIFF
--- a/dtschema/fixups.py
+++ b/dtschema/fixups.py
@@ -59,7 +59,7 @@ def _is_matrix_schema(subschema):
 
 
 int_array_re = re.compile('int(8|16|32|64)-array')
-unit_types_re = re.compile('-(bps|kBps|bits|percent|bp|m?hz|sec|ms|us|ns|ps|mm|nanoamp|(micro-)?ohms|micro(amp|watt)(-hours)?|milliwatt|microvolt|picofarads|(milli)?celsius|kelvin|k?pascal)$')
+unit_types_re = re.compile('-(bps|kbps|mbps|kBps|bits|percent|bp|m?hz|sec|ms|us|ns|ps|mm|nanoamp|(micro-)?ohms|micro(amp|watt)(-hours)?|milliwatt|microvolt|picofarads|(milli)?celsius|kelvin|k?pascal)$')
 
 # Remove this once we remove array to matrix fixups
 known_array_props = {

--- a/dtschema/meta-schemas/core.yaml
+++ b/dtschema/meta-schemas/core.yaml
@@ -58,7 +58,7 @@ definitions:
         propertyNames:
           enum: [ description, deprecated ]
 
-      '-(bits|bps|kBps|percent|bp|mhz|hz|sec|ms|us|ns|ps|mm|nanoamp|microamp(-hours)?|(micro-)?ohms|microwatt-hours|microvolt|(femto|pico)farads|(milli)?celsius|kelvin|k?pascal)$':
+      '-(bits|bps|kbps|mbps|kBps|percent|bp|mhz|hz|sec|ms|us|ns|ps|mm|nanoamp|microamp(-hours)?|(micro-)?ohms|microwatt-hours|microvolt|(femto|pico)farads|(milli)?celsius|kelvin|k?pascal)$':
         allOf:
           - $ref: cell.yaml#/array
           - description: Standard unit suffix properties don't need a type $ref

--- a/dtschema/meta-schemas/vendor-props.yaml
+++ b/dtschema/meta-schemas/vendor-props.yaml
@@ -15,7 +15,7 @@ patternProperties:
   '-(gpio|gpios)$': true
   '-supply$': true
   '^rcar_sound,': true
-  '-(bits|bps|kBps|percent|bp|mhz|hz|sec|ms|us|ns|ps|mm)$': true
+  '-(bits|bps|kbps|mbps|kBps|percent|bp|mhz|hz|sec|ms|us|ns|ps|mm)$': true
   '-(nanoamp|microamp|microamp-hours|ohms|micro-ohms|microwatt-hours)$': true
   '-(microvolt|(femto|pico)farads|celsius|millicelsius|kelvin|k?pascal)$': true
 

--- a/dtschema/schemas/property-units.yaml
+++ b/dtschema/schemas/property-units.yaml
@@ -37,6 +37,14 @@ patternProperties:
     $ref: types.yaml#/definitions/uint32
     description: bits per second
 
+  "-kbps$":
+    $ref: types.yaml#/definitions/uint32
+    description: kilobits per second
+
+  "-mbps$":
+    $ref: types.yaml#/definitions/uint32
+    description: megabits per second
+
   "-kBps$":
     $ref: types.yaml#/definitions/uint32-array
     description: kilobytes per second


### PR DESCRIPTION
Some data rates might be too large to be represented as bits per second. Add kilobits per second (kbps) and megabits per second (mbps) to address that.