### PR TITLE
README: fix broken link to json-schema.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The dtschema module contains tools and schema data for Devicetree
 schema validation using the
-[json-schema](http://json-schema.org/documentation.html) vocabulary.
+[json-schema](https://json-schema.org) vocabulary.
 The tools validate Devicetree files using DT binding schema files. The
 tools also validate the DT binding schema files. Schema files are
 written in a JSON compatible subset of YAML to be both human and machine


### PR DESCRIPTION
The link to the documentation is not valid anymore. There are at least two sections that might be used as a replacement ("Specification" and "Getting Started"), but to avoid a broken link in the future, point to the main site.