### PR TITLE
schemas: pci: allow additional device properties in pci-pci-bridge

### DIFF
--- a/dtschema/schemas/pci/pci-pci-bridge.yaml
+++ b/dtschema/schemas/pci/pci-pci-bridge.yaml
@@ -34,4 +34,4 @@ properties:
       to D3 states.
     type: boolean
 
-unevaluatedProperties: false
+additionalProperties: true


### PR DESCRIPTION
Device schemas referencing pci-pci-bridge.yaml might have additional properties.