### PR TITLE
validator: Don't crash if the de-aliaser hack fails

### DIFF
--- a/dtschema/validator.py
+++ b/dtschema/validator.py
@@ -192,7 +192,10 @@ def get_prop_types(schemas):
     props = extract_types(schemas)
 
     # hack to remove aliases and generic patterns
-    del props[r'^[a-z][a-z0-9\-]*$']
+    try:
+        del props[r'^[a-z][a-z0-9\-]*$']
+    except:
+        pass
 
     # Remove all node types
     for val in props.values():


### PR DESCRIPTION
This can apparently fall off the bike:

SCHEMA  Documentation/devicetree/bindings/processed-schema.json Traceback (most recent call last):
  File "/home/konrad/.local/bin/dt-mk-schema", line 38, in <module>
    schemas = dtschema.DTValidator(args.schemas).schemas
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/site-packages/dtschema/validator.py", line 373, in __init__
    self.make_property_type_cache()
  File "/usr/lib/python3.12/site-packages/dtschema/validator.py", line 460, in make_property_type_cache
    self.props, self.pat_props = get_prop_types(self.schemas)
                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/site-packages/dtschema/validator.py", line 195, in get_prop_types
    del props[r'^[a-z][a-z0-9\-]*$']
        ~~~~~^^^^^^^^^^^^^^^^^^^^^^^
KeyError: '^[a-z][a-z0-9\\-]*$'
make[2]: *** [Documentation/devicetree/bindings/Makefile:64: Documentation/devicetree/bindings/processed-schema.json] Błąd 1