### PR TITLE
Automatically allow OSs to create dedicated memory allocators

### DIFF
--- a/dtschema/schemas/reserved-memory/reserved-memory.yaml
+++ b/dtschema/schemas/reserved-memory/reserved-memory.yaml
@@ -66,6 +66,12 @@ properties:
       which can be corrected by the Error-Correction Code (ECC) memory
       subsystem (typically 0, 1 or 2).
 
+  export:
+    type: boolean
+    description: >
+      The operating system can use the memory to create special-purpose
+      allocators instead of solely dedicating it to the device.
+
   iommu-addresses:
     $ref: /schemas/types.yaml#/definitions/phandle-array
     description: >

--- a/dtschema/schemas/reserved-memory/reserved-memory.yaml
+++ b/dtschema/schemas/reserved-memory/reserved-memory.yaml
@@ -52,6 +52,20 @@ properties:
       Address and Length pairs. Specifies regions of memory that are
       acceptable to allocate from.
 
+  ecc-detection-bits:
+    default: 0
+    description: |
+      If present, this indicates the number of bits of memory error
+      which can be detected and reported by the Error-Correction Code
+      (ECC) memory subsystem (typically 0, 1 or 2).
+
+  ecc-correction-bits:
+    default: 0
+    description: |
+      If present, this indicates the number of bits of memory error
+      which can be corrected by the Error-Correction Code (ECC) memory
+      subsystem (typically 0, 1 or 2).
+
   iommu-addresses:
     $ref: /schemas/types.yaml#/definitions/phandle-array
     description: >


### PR DESCRIPTION
Here's a draft series to add the ability for the OS to create dedicated memory allocators from carved-out memory regions with memory attributes or parameters different from the rest of the system.

This is useful, for example, on systems with ECC enabled to create dedicated memory regions where ECC is disabled so the system is protected by default, but we can still opt-out of that protection for usage specific buffers. For example, framebuffers are usually fairly big, and a bitflip would marginally affect the color of a pixel. This doesn't justify the downsides of enabling ECC on some platforms (increased memory usage, lower performance).

Thanks for looking into it!