### PR TITLE
schemas: introduce assigned-clock-rates-u64

### DIFF
--- a/dtschema/fixups.py
+++ b/dtschema/fixups.py
@@ -413,6 +413,7 @@ def fixup_node_props(schema):
 
     if "clocks" in keys and "assigned-clocks" not in keys:
         schema['properties']['assigned-clocks'] = True
+        schema['properties']['assigned-clock-rates-u64'] = True
         schema['properties']['assigned-clock-rates'] = True
         schema['properties']['assigned-clock-parents'] = True
 

--- a/dtschema/meta-schemas/clocks.yaml
+++ b/dtschema/meta-schemas/clocks.yaml
@@ -21,6 +21,8 @@ properties:
     $ref: cell.yaml#/array
   assigned-clock-rates:
     $ref: cell.yaml#/array
+  assigned-clock-rates-u64:
+    $ref: cell.yaml#/array
 
   clock-frequency:
     $ref: cell.yaml#/single
@@ -35,3 +37,4 @@ dependentRequired:
   assigned-clocks: [clocks]
   assigned-clock-parents: [assigned-clocks]
   assigned-clock-rates: [assigned-clocks]
+  assigned-clock-rates-u64: [assigned-clocks]

--- a/dtschema/schemas/clock/clock.yaml
+++ b/dtschema/schemas/clock/clock.yaml
@@ -129,6 +129,8 @@ properties:
     $ref: /schemas/types.yaml#/definitions/phandle-array
   assigned-clock-rates:
     $ref: /schemas/types.yaml#/definitions/uint32-array
+  assigned-clock-rates-u64:
+    $ref: /schemas/types.yaml#/definitions/uint64-array
 
   protected-clocks:
     $ref: /schemas/types.yaml#/definitions/uint32-array
@@ -147,6 +149,7 @@ dependentRequired:
   clock-ranges: [clocks]
   assigned-clock-parents: [assigned-clocks]
   assigned-clock-rates: [assigned-clocks]
+  assigned-clock-rates-u64: [assigned-clocks]
   protected-clocks: ["#clock-cells"]
 
 dependentSchemas:


### PR DESCRIPTION
To support rates that exceeds UINT32_MAX, introduce assigned-clock-rates-u64