### PR TITLE
schemas: core: Introduce "fail-needs-probe" status

### DIFF
--- a/dtschema/schemas/dt-core.yaml
+++ b/dtschema/schemas/dt-core.yaml
@@ -56,7 +56,7 @@ properties:
     oneOf:
       - type: object
       - $ref: types.yaml#/definitions/string
-        enum: [ okay, disabled, reserved, fail ]
+        enum: [ okay, disabled, reserved, fail, fail-needs-probe ]
   phandle:
     $ref: types.yaml#/definitions/uint32
 


### PR DESCRIPTION
Some components can not be absolutely determined to exist on a given device when the device tree is written or compiled. However such components can either be probed using I2C transfers, or determined to exist based on runtime information, such as GPIO or ADC strappings, or extra information passed over from boot firmware or read from some flash chip.

Such an arrangement of components are commonly seen in the consumer electronics world, where the manufacturer will swap out electrically compatible components due to inventory or price constraints. These components are commonly attached to the baseboard with a standardized ribbon cable, and the ribbon cable may contain strapping resistors if necessary.

Introduce a new "fail-needs-probe" status string that corresponds to devices or components that "might" exist. (The term "component" shall be used to avoid confusion with the actual "complete device".) This status signals that the implementation needs to do extra probing to determine the exact state of the component.