### PR TITLE
schemas: root-node: Add 'television' chassis-type

### DIFF
--- a/dtschema/schemas/root-node.yaml
+++ b/dtschema/schemas/root-node.yaml
@@ -27,6 +27,7 @@ properties:
       - handset
       - watch
       - embedded
+      - television
   "#address-cells":
     enum: [1, 2]
   "#size-cells":


### PR DESCRIPTION
The 'television' chassis-type includes Smart TVs and set-top boxes, or any remote-controlled displays in general.

---

Hi,
I plan to use this chassis type in version 2 of the patches to add [initial device trees for Apple A7-A11 SoC based devices](https://lore.kernel.org/asahi/20240911084353.28888-2-towinchenmi@gmail.com/),
which includes Apple TV.

Relevant documentation PR: https://github.com/devicetree-org/devicetree-specification/pull/79

Nick Chan