### PR TITLE
Add schema for GPIO nexus nodes

### DIFF
--- a/dtschema/schemas/gpio/gpio-nexus-node.yaml
+++ b/dtschema/schemas/gpio/gpio-nexus-node.yaml
@@ -1,0 +1,30 @@
+# SPDX-License-Identifier: BSD-2-Clause
+# Copyright Ayush Singh <ayush@beagleboard.org>
+
+$id: http://devicetree.org/schemas/gpio/gpio-nexus-node.yaml#
+$schema: http://devicetree.org/meta-schemas/base.yaml#
+
+title: GPIO Nexus node properties
+
+description: Schema for nexus node devicetree bindings
+maintainers:
+  - Ayush Singh <ayush@beagleboard.org>
+
+# always select the core schema
+select: true
+
+properties:
+  "#gpio-cells": true
+  gpio-map:
+    $ref: /schemas/types.yaml#/definitions/uint32-matrix
+  gpio-map-mask:
+    $ref: types.yaml#/definitions/uint32-array
+  gpio-map-pass-thru:
+    $ref: types.yaml#/definitions/uint32-array
+
+dependentRequired:
+  gpio-map: ['#gpio-cells']
+  'gpio-map-mask': [ gpio-map ]
+  'gpio-map-pass-thru': [ gpio-map ]
+
+additionalProperties: true

--- a/dtschema/schemas/gpio/gpio.yaml
+++ b/dtschema/schemas/gpio/gpio.yaml
@@ -35,10 +35,9 @@ properties:
 
 dependencies:
   gpio-controller: ['#gpio-cells']
-  '#gpio-cells': [ gpio-controller ]
-  gpio-line-names: ['#gpio-cells']
-  ngpios: ['#gpio-cells']
-  gpio-reserved-ranges: ['#gpio-cells']
-  gpio-ranges: ['#gpio-cells']
+  gpio-line-names: ['#gpio-cells', gpio-controller]
+  ngpios: ['#gpio-cells', gpio-controller]
+  gpio-reserved-ranges: ['#gpio-cells', gpio-controller]
+  gpio-ranges: ['#gpio-cells', gpio-controller]
 
 additionalProperties: true


### PR DESCRIPTION
[Nexus nodes](https://devicetree-specification.readthedocs.io/en/v0.3/devicetree-basics.html#nexus-nodes-and-specifier-mapping) were introduced with devicetree specification 0.3 and allow routing gpios, clock, etc to different controllers, etc.

Here I am trying to introduce GPIO nexus node binding since I am not sure how dependence for a general nexus node might be written.

I am also removing `#gpio-cells` dependence on `gpio-controller` since nexus node is not a controller.