### PR TITLE
dt-bindings: u-boot: Add property for LED boot and activity

### DIFF
--- a/dtschema/schemas/options/u-boot.yaml
+++ b/dtschema/schemas/options/u-boot.yaml
@@ -110,6 +110,26 @@ properties:
         enabled)
       2: console output is suppressed and not recorded
 
+  boot-led:
+    $ref: /schemas/types.yaml#/definitions/phandle
+    description: |
+      This is used to specify a phandle to an LED to indicate a successful boot.
+
+  boot-led-period-ms:
+    default: 250
+    description: |
+      This is used to specify the default period (in ms) for an LED in blink mode.
+
+  activity-led:
+    $ref: /schemas/types.yaml#/definitions/phandle
+    description: |
+      This is used to specify a phandle to an LED to indicate an activity.
+
+  activity-led-period-ms:
+    default: 250
+    description: |
+      This is used to specify the default period (in ms) for an LED in blink mode.
+
 required:
   - compatible
 


### PR DESCRIPTION
Add property for LED boot and activity and period for blink mode.

These property define the LED label to use for the u-boot boot or activity LED to signal successful boot or activity like flash write or tftp traffic.