### PR TITLE
schemas: pci: bridge: Document PCIe equalization presets

### DIFF
--- a/dtschema/schemas/pci/pci-bus-common.yaml
+++ b/dtschema/schemas/pci/pci-bus-common.yaml
@@ -159,6 +159,46 @@ properties:
   vpcie3v3aux-supply:
     description: 3.3v AUX regulator phandle for the slot
 
+  eq-presets-8gts:
+    description:
+      Contains the equalization preset values for PCIe data rates 8.0 GT/s.
+      Each preset value is used to adjust the transmitter settings to improve
+      signal quality and meet the electrical requirements. These preset values
+      go in Lane Equalization Control registers (PCIe r6.0, sec 7.7.3.4).
+    $ref: /schemas/types.yaml#/definitions/uint16-array
+    minItems: 1
+    maxItems: 16
+
+  eq-presets-16gts:
+    description:
+      Contains the equalization preset values for PCIe data rates 16.0 GT/s.
+      Each preset value is used to adjust the transmitter settings to improve
+      signal quality and meet the electrical requirements. These preset values
+      go in Lane Equalization Control registers (PCIe r6.0, sec 7.7.5.9).
+    $ref: /schemas/types.yaml#/definitions/uint8-array
+    minItems: 1
+    maxItems: 16
+
+  eq-presets-32gts:
+    description:
+      Contains the equalization preset values for PCIe data rates 32.0 GT/s.
+      Each preset value is used to adjust the transmitter settings to improve
+      signal quality and meet the electrical requirements. These preset values
+      go in Lane Equalization Control registers (PCIe r6.0, sec 7.7.6.9).
+    $ref: /schemas/types.yaml#/definitions/uint8-array
+    minItems: 1
+    maxItems: 16
+
+  eq-presets-64gts:
+    description:
+      Contains the equalization preset values for PCIe data rates 64.0 GT/s.
+      Each preset value is used to adjust the transmitter settings to improve
+      signal quality and meet the electrical requirements. These preset values
+      go in Lane Equalization Control registers (PCIe r6.0, sec 7.7.7.5).
+    $ref: /schemas/types.yaml#/definitions/uint8-array
+    minItems: 1
+    maxItems: 16
+
 patternProperties:
   "@1?[0-9a-f](,[0-7])?$":
     type: object


### PR DESCRIPTION
PCIe equalization presets are predefined settings used to optimize signal integrity by compensating for signal loss and distortion in high-speed data transmission.

As per PCIe spec 6.0.1 revision section 8.3.3.3 & 4.2.4 for data rates of  8.0 GT/s, 16.0 GT/s, 32.0 GT/s and 64.0 GT/s provides a way to configure lane equalization presets for each lane to enhance the PCIe link reliability. Each preset value represents a different combination of pre-shoot and de-emphasis values.

For each data rate it may be required to have a different preset configuration and each lane will have different preset values.

Define per data rate equalization preset property with array of 16 representing 16 lanes of the PCIe.