### PR TITLE
dt-bindings: trigger: Add trigger source

### DIFF
--- a/dtschema/schemas/trigger/trigger-source.yaml
+++ b/dtschema/schemas/trigger/trigger-source.yaml
@@ -1,0 +1,33 @@
+# SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+%YAML 1.2
+---
+$id: http://devicetree.org/schemas/trigger/trigger-source.yaml#
+$schema: http://devicetree.org/meta-schemas/core.yaml#
+
+title: Trigger source provider
+
+maintainers:
+  - David Lechner <dlechner@baylibre.com>
+
+description:
+  A trigger source providers are an abstraction for anything that provides a
+  signal to trigger an event. For example, this could be a disk activity signal
+  that triggers a LED to turn on or off or it could be a data ready signal
+  that triggers a SPI offload to read data without a software interrupt. Each
+  trigger source provider should be represented by a device tree node.
+
+select: true
+
+properties:
+  '#trigger-source-cells':
+    description:
+      Number of cells required to specify a trigger source. This property is
+      is applied to the trigger source provider.
+
+  trigger-sources:
+    $ref: /schemas/types.yaml#/definitions/phandle-array
+    description:
+      This property is applied to the trigger source consumer to describe the
+      connection to a trigger source provider.
+
+additionalProperties: true


### PR DESCRIPTION
Add a new binding for trigger source providers and consumers. This is essentially the trigger source bindings from the leds subsystem in the Linux kernel, but with more generic descriptions and no restrictions on #trigger-source-cells.

As requested in https://lore.kernel.org/linux-spi/20241119164429.GB1769375-robh@kernel.org/