### PR TITLE
schemas: Add access controller consumer

### DIFF
--- a/dtschema/schemas/access-controller/access-controller-consumer.yaml
+++ b/dtschema/schemas/access-controller/access-controller-consumer.yaml
@@ -1,0 +1,22 @@
+# SPDX-License-Identifier: BSD-2-Clause
+# Copyright 2024 NXP
+%YAML 1.2
+---
+$id: http://devicetree.org/schemas/access-controller/access-controller-consumer.yaml#
+$schema: http://devicetree.org/meta-schemas/core.yaml#
+
+title: Access Controller Consumer Properties
+
+maintainers:
+  - Peng Fan <peng.fan@nxp.com>
+
+select: true
+
+properties:
+  access-controllers:
+    $ref: /schemas/types.yaml#/definitions/phandle-array
+    description:
+      This property is applied to the access controller consumer to describe
+      the connection to an access controller provider.
+
+additionalProperties: true


### PR DESCRIPTION
Add a new binding access controller consumers. There are bus resource domain controllers, eFuse access controllers, so add the consumer bindings for various nodes to use.