### PR TITLE
schemas: wakeup-source: Possibility for power states

### DIFF
--- a/dtschema/schemas/system-idle-states.yaml
+++ b/dtschema/schemas/system-idle-states.yaml
@@ -1,0 +1,70 @@
+# SPDX-License-Identifier: BSD-2-Clause
+# Copyright 2025 BayLibre
+%YAML 1.2
+---
+$id: http://devicetree.org/schemas/system-idle-states.yaml#
+$schema: http://devicetree.org/meta-schemas/core.yaml#
+
+title: System Idle States
+
+maintainers:
+  - Markus Schneider-Pargmann <msp@baylibre.com>
+
+description:
+  A system idle state node represents a system state that can have certain
+  limitations and power properties.
+
+properties:
+  $nodename:
+    const: system-idle-states
+
+patternProperties:
+  "^system-[a-z0-9-]+$":
+    type: object
+    additionalProperties: false
+    description:
+      The node represents a system state description.
+
+    properties:
+      compatible:
+        const: system-idle-state
+
+      idle-state-name:
+        $ref: /schemas/types.yaml#/definitions/string
+        description: |
+          Name of the system state. These are the available states:
+          - standby: Light suspend, peripherals may remain active
+          - mem-mcu-active: DDR in self-refresh, MCU/coprocessor running,
+            main cores off
+          - mem: DDR in self-refresh, all cores off
+          - mem-deep: DDR in self-refresh, all other hardware off except
+            some wake logic
+          - off-wake: System powered off, wake-up logic remains active
+          - off: Complete power off, lowest possible power state
+        enum:
+          - standby
+          - mem-mcu-active
+          - mem
+          - mem-deep
+          - off-wake
+          - off
+
+    required:
+      - compatible
+      - idle-state-name
+
+additionalProperties: false
+
+examples:
+  - |
+    system-idle-states {
+      system-suspend {
+        compatible = "system-idle-state";
+        idle-state-name = "mem";
+      };
+
+      system-off {
+        compatible = "system-idle-state";
+        idle-state-name = "off";
+      };
+    };

--- a/dtschema/schemas/wakeup-source.yaml
+++ b/dtschema/schemas/wakeup-source.yaml
@@ -9,7 +9,9 @@ title: Wakeup sources
 
 description: >
   Nodes that describe devices which have wakeup capability may contain a
-  "wakeup-source" boolean property.
+  "wakeup-source" property. This property can be either boolean or a phandle
+  array containing references to system idle states in which this device has a
+  wakeup capability.
 
   If the device is marked as a wakeup-source, interrupt wake capability depends
   on the device specific "interrupt-names" property. If no interrupts are labeled
@@ -30,7 +32,12 @@ select: true
 
 properties:
   wakeup-source:
-    type: boolean
+    oneOf:
+      - type: boolean
+      - $ref: /schemas/types.yaml#/definitions/phandle-array
+        description: >
+          List of phandles to system idle state nodes. The device can be a
+          wakeup source in the given system states.
 
 additionalProperties: true
 
@@ -68,5 +75,14 @@ examples:
             label = "POWER";
             gpios = <&iofpga_gpio0 0 0x4>;
         };
+    };
+  - |
+    # With power states specified
+    mcu_mcan0: can@4e08000 {
+        compatible = "bosch,m_can";
+        reg = <0x00 0x4e08000 0x00 0x200>,
+              <0x00 0x4e00000 0x00 0x8000>;
+        reg-names = "m_can", "message_ram";
+        wakeup-source = <&system_partial_io>, <&system_deep_sleep>;
     };
 ...


### PR DESCRIPTION
wakeup-source in its current form ignores power states. But with modern SoCs there are many powerstates that have a different set of devices enabled. Also there are more complex wakeup mechanisms available.

As an example TI's am62 SoC has a power state called 'Partial-IO' in which most of the SoC is powered off and only a small device logic is present for a few select devices that can still wakeup the SoC. But most devices that are usually able to wakeup the SoC are not capable to do it in Partial-IO.

In order to properly describe the wakeup-source property depending on the power state, this patch extends the definition to be either boolean or a list of power state names in which this device is capable of wakeup.

This is the Linux Kernel series that adds support for Partial-IO:
https://lore.kernel.org/all/20241219-topic-am62-partialio-v6-12-b4-v4-0-1cb8eabd407e@baylibre.com/

This is was my previous patch adding this binding before realizing the wakeup-source property is defined in this schema repository:
https://lore.kernel.org/all/20241219-topic-mcan-wakeup-source-v6-12-v6-1-1356c7f7cfda@baylibre.com/