### PR TITLE
schemas: gpio: Restrict HOG node name pattern to suffixes

### DIFF
--- a/dtschema/schemas/gpio/gpio-hog.yaml
+++ b/dtschema/schemas/gpio/gpio-hog.yaml
@@ -20,7 +20,7 @@ select:
 
 properties:
   $nodename:
-    pattern: "^(hog-[0-9]+|.+-hog(-[0-9]+)?)$"
+    pattern: "-hog(-[0-9]+)?$"
 
   gpio-hog:
     $ref: /schemas/types.yaml#/definitions/flag


### PR DESCRIPTION
Bring some sort of uniformity by allowing only "-hog" suffix, not prefix, for gpio-hog node names.

There is only one user of dropped prefix pattern in the Linux kernel DTS, being fixed in patch:
https://lore.kernel.org/linux-devicetree/20250115204603.136997-1-krzysztof.kozlowski@linaro.org/