### PR TITLE
schemas: property-units: Add the picoamp type

### DIFF
--- a/dtschema/schemas/property-units.yaml
+++ b/dtschema/schemas/property-units.yaml
@@ -85,6 +85,9 @@ patternProperties:
   "-nanoamp$":
     $ref: types.yaml#/definitions/uint32-array
     description: nanoampere
+  "-picoamp$":
+    $ref: types.yaml#/definitions/uint32-array
+    description: picoampere
   "-microamp-hours$":
     $ref: types.yaml#/definitions/uint32-array
     description: microampere hour


### PR DESCRIPTION
Add the picoamp type.
This will be required for a new revision of a dt-bindings patch for. Series here:
[https://lore.kernel.org/r/20250106-apds9160-driver-v4-0-f88d9fc45d84@dimonoff.com](url)

Relevant comment regarding this change here:
[https://lore.kernel.org/all/20250118114846.78ce0b67@jic23-huawei/](url)

