### PR TITLE
schemas: introduce assigned-clock-sscs

### DIFF
--- a/dtschema/fixups.py
+++ b/dtschema/fixups.py
@@ -351,6 +351,7 @@ def fixup_node_props(schema):
         schema['properties']['assigned-clock-rates-u64'] = True
         schema['properties']['assigned-clock-rates'] = True
         schema['properties']['assigned-clock-parents'] = True
+        schema['properties']['assigned-clock-sscs'] = True
 
 
 # Convert to standard types from ruamel's CommentedMap/Seq

--- a/dtschema/meta-schemas/clocks.yaml
+++ b/dtschema/meta-schemas/clocks.yaml
@@ -23,6 +23,8 @@ properties:
     $ref: cell.yaml#/array
   assigned-clock-rates-u64:
     $ref: cell.yaml#/array
+  assigned-clock-sscs:
+    $ref: cell.yaml#/array
 
   clock-frequency:
     $ref: cell.yaml#/single
@@ -38,3 +40,4 @@ dependentRequired:
   assigned-clock-parents: [assigned-clocks]
   assigned-clock-rates: [assigned-clocks]
   assigned-clock-rates-u64: [assigned-clocks]
+  assigned-clock-sscs: [assigned-clocks]

--- a/dtschema/schemas/clock/clock.yaml
+++ b/dtschema/schemas/clock/clock.yaml
@@ -131,6 +131,15 @@ properties:
     $ref: /schemas/types.yaml#/definitions/uint32-array
   assigned-clock-rates-u64:
     $ref: /schemas/types.yaml#/definitions/uint64-array
+  assigned-clock-sscs:
+    $ref: /schemas/types.yaml#/definitions/uint32-matrix
+    items:
+      items:
+        - description: The modulation frequency
+        - description: The modulation percentage
+        - description: The modulation method, down(2), up(1), center(0)
+          minimum: 0
+          maximum: 2
 
   protected-clocks:
     $ref: /schemas/types.yaml#/definitions/uint32-array
@@ -150,6 +159,7 @@ dependentRequired:
   assigned-clock-parents: [assigned-clocks]
   assigned-clock-rates: [assigned-clocks]
   assigned-clock-rates-u64: [assigned-clocks]
+  assigned-clock-sscs: [assigned-clocks]
   protected-clocks: ["#clock-cells"]
 
 dependentSchemas:


### PR DESCRIPTION
To support spread spectrum clock, introduce assigned-clock-sscs, it is an uint32-matrix with format multiple elements of below
<modfreq spreadpercentage modmethod>, <...>