### PR TITLE
schemas: root-node: add 'spectacles' chassis-type

### DIFF
--- a/dtschema/schemas/root-node.yaml
+++ b/dtschema/schemas/root-node.yaml
@@ -28,6 +28,7 @@ properties:
       - watch
       - embedded
       - television
+      - spectacles
   "#address-cells":
     enum: [1, 2]
   "#size-cells":


### PR DESCRIPTION
With the growing interest in the AR/VR/XR devices, it is expected that more and more devices will have the spectacles or eyeglasses-like form factor. Follow the devicetree specification change and add 'spectacles' as to list of possible values for the 'chassis-type' property.