### PR TITLE
Fix crash caused by spurious aliases phandles.

### DIFF
--- a/dtschema/dtb.py
+++ b/dtschema/dtb.py
@@ -82,7 +82,7 @@ def prop_value(validator, nodename, p):
     data = bytes(p)
     fmt = None
 
-    if nodename in {'__fixups__', 'aliases'}:
+    if nodename in {'__fixups__'}:
         return data[:-1].decode(encoding='ascii').split('\0')
 
     prop_types = set(validator.property_get_type(p.name))


### PR DESCRIPTION
If a device tree has specified a phandle for an aliases node, perhaps appearing as "aliases: aliases" in the device tree source, the phandle property will occur in the device tree data for the node.

If this property value is not decoded appropriately by prop_value, fdt_scan_node will raise a TypeError trying to use the inappropriately decoded value as a dictionary key when recording a phandle-to-node association. This effectively crashes the tool.

This modification lets prop_value decode property values normally instead of treating aliases nodes as a special case. Any phandle associated with such a node will then be reported by the validator in a message of the following form:

aliases: phandle: 26 is not of type 'array'

This is somewhat opaque and could arguably be reported in a more helpful way, but it indicates the presence of the spurious phandle instead of terminating abruptly.