### PR TITLE
schemas: root-node: Add 'all-in-one' chassis-type

### DIFF
--- a/dtschema/schemas/root-node.yaml
+++ b/dtschema/schemas/root-node.yaml
@@ -23,6 +23,7 @@ properties:
       - laptop
       - convertible
       - server
+      - all-in-one
       - tablet
       - handset
       - watch


### PR DESCRIPTION
All in One PCs are desktop computers with integrated display. The Linux kernel contains device trees for Apple silicon iMacs (24-inch, M1, 2021) [0] which should use this chassis-type.
The SMBIOS specification [1] specifies "All in One" as `0Dh` in "Table 17 – System Enclosure or Chassis Types" as well.

[0] arch/arm64/boot/dts/apple/t8103-j45[67].dts
[1] https://www.dmtf.org/sites/default/files/standards/documents/DSP0134_3.8.0.pdf