### PR TITLE
[RFC] schemas: chosen: describe new arm,security-state property

### DIFF
--- a/dtschema/schemas/chosen.yaml
+++ b/dtschema/schemas/chosen.yaml
@@ -66,6 +66,17 @@ properties:
 
       This random value should be provided by bootloader.
 
+  arm,security-state:
+    $ref: types.yaml#/definitions/string
+    enum: [ non-secure, secure ]
+    description:
+      This property indicates the boot CPU's security state at the time
+      control was handed off to the OS. It's mainly useful on ARMv7,
+      where no generic mechanism exists to query the security state.
+      The OS can make use of this information to skip privileged errata
+      fixups that are off limits for non-secure software executing
+      in the normal world.
+
   linux,booted-from-kexec:
     type: boolean
     description:


### PR DESCRIPTION
We once again stumbled over errata fixups that were applied twice, first in the barebox bootloader and then in the Linux kernel. This went unnoticed at first, but with OP-TEE enabled as a secure monitor, the system hangs very early before regular console output is available.

The Linux kernel errata fixes for non-ARCH_MULTIPLATFORM will likely never go away, because bootloaders may not be updatable in the field and sometimes don't even suffer from the consequences, e.g. because they affect only SMP.

Therefore, let's add at least a way for the bootloader to tell the OS about whether it's running in the secure world or not.
