### PR TITLE
schemas: chosen: document barebox-version property

### DIFF
--- a/dtschema/schemas/chosen.yaml
+++ b/dtschema/schemas/chosen.yaml
@@ -241,6 +241,13 @@ properties:
       This property is used by U-Boot to pass its version down to the operating
       system.
 
+  barebox-version:
+    $ref: types.yaml#/definitions/string
+    pattern: "^barebox-20[0-9]{2}\\.[0-9]{2}.*$"
+    description:
+      This property is used by barebox to pass its version down to the operating
+      system.
+
 patternProperties:
   "^framebuffer": true
 


### PR DESCRIPTION
barebox started[1] fixing up its version as `/chosen/barebox-version` with release v2018.05.0. The feature is documented here[2].

[1]: https://github.com/barebox/barebox/commit/e96dc23280c43dd6b026ea71bcbaf3353abb4c83
[2]: https://www.barebox.org/doc/latest/user/versioning.html#query-from-os