### PR TITLE
schemas: Add 'db' property unit

### DIFF
--- a/dtschema/fixups.py
+++ b/dtschema/fixups.py
@@ -80,7 +80,7 @@ def _fixup_remove_empty_items(subschema):
 
 
 # Keep in sync with property-units.yaml
-unit_types_array_re = re.compile('-(kBps|bits|percent|bp|mhz|sec|ms|us|ns|ps|mm|nanoamp|(micro-)?ohms|micro(amp|watt)(-hours)?|milliwatt|(femto|pico)farads|(milli)?celsius|kelvin|k?pascal)$')
+unit_types_array_re = re.compile('-(kBps|bits|percent|bp|db|mhz|sec|ms|us|ns|ps|mm|nanoamp|(micro-)?ohms|micro(amp|watt)(-hours)?|milliwatt|(femto|pico)farads|(milli)?celsius|kelvin|k?pascal)$')
 unit_types_matrix_re = re.compile('-(hz|microvolt)$')
 
 def _fixup_unit_suffix_props(subschema, path=[]):

--- a/dtschema/meta-schemas/core.yaml
+++ b/dtschema/meta-schemas/core.yaml
@@ -66,7 +66,7 @@ definitions:
         propertyNames:
           enum: [ description, deprecated ]
 
-      '-(bits|bps|kBps|percent|bp|mhz|hz|sec|ms|us|ns|ps|mm|nanoamp|microamp(-hours)?|micro-ohms|microwatt-hours|microvolt|(femto|pico)farads|(milli)?celsius|kelvin|k?pascal)$':
+      '-(bits|bps|kBps|percent|bp|db|mhz|hz|sec|ms|us|ns|ps|mm|nanoamp|microamp(-hours)?|micro-ohms|microwatt-hours|microvolt|(femto|pico)farads|(milli)?celsius|kelvin|k?pascal)$':
         $ref: '#/definitions/unit-suffix-properties'
 
       # Some special cases which don't match the normal size.

--- a/dtschema/meta-schemas/vendor-props.yaml
+++ b/dtschema/meta-schemas/vendor-props.yaml
@@ -19,7 +19,7 @@ patternProperties:
   '-(gpio|gpios)$': true
   '-supply$': true
   '^rcar_sound,': true
-  '-(bits|bps|kBps|percent|bp|mhz|hz|sec|ms|us|ns|ps|mm)$': true
+  '-(bits|bps|kBps|percent|bp|db|mhz|hz|sec|ms|us|ns|ps|mm)$': true
   '-(nanoamp|microamp|microamp-hours|ohms|micro-ohms|microwatt-hours)$': true
   '-(microvolt|(femto|pico)farads|celsius|millicelsius|kelvin|k?pascal)$': true
 

--- a/dtschema/schemas/property-units.yaml
+++ b/dtschema/schemas/property-units.yaml
@@ -49,6 +49,10 @@ patternProperties:
     $ref: types.yaml#/definitions/int32-array
     description: basis points (1/100 of a percent)
 
+  "-db$":
+    $ref: types.yaml#/definitions/int32-array
+    description: decibels
+
   # Time/Frequency
   "-mhz$":
     $ref: types.yaml#/definitions/uint32-array


### PR DESCRIPTION
Add property unit for decibels (dB) already used in Linux kernel (e.g. "audio-gain-db").