### PR TITLE
schemas: chosen: add bootsource property

### DIFF
--- a/dtschema/schemas/chosen.yaml
+++ b/dtschema/schemas/chosen.yaml
@@ -32,6 +32,30 @@ properties:
   bootargs:
     $ref: types.yaml#/definitions/string
 
+  bootsource:
+    $ref: types.yaml#/definitions/string
+    description:
+      This property represents the full path to the node representing the device
+      the BootROM used to load the initial boot program, e.g.
+
+      / {
+              chosen {
+                      bootsource = "/mmc@ff390000";
+              };
+      };
+
+      If the initial boot program is split into multiple stages, this represents
+      the storage medium or device (e.g. used by fastboot) from which the very
+      first stage was loaded by the BootROM.
+
+      It may differ from the device from which later stages of the boot program
+      or client program are loaded from, as this property isn't meant to
+      represent those devices.
+
+      A later stage of the boot program, or the client program, may use this
+      information to favor the device in this property over others for loading
+      later stages, or know the storage medium to flash an update to.
+
   kaslr-seed:
     $ref: types.yaml#/definitions/uint64
     description:


### PR DESCRIPTION
Bootloaders typically can be loaded from different storage media, such as eMMC, SD card, SPI flash, EEPROM, but also from non-persistent media such as USB (via proprietary protocols loading directly into SRAM, or fastboot, DFU, etc..), JTAG, ...

This information is usually reported by the SoC-ROM via some proprietary mechanism (some specific address in registers/DRAM for example).

It would be useful to know which medium was used to load the first stage of the bootloader. SoC-ROM shall be ignored and not reported in this property.

This can allow client programs to detect which medium to write to when updating the boot program, or detect if fallback mechanisms to unexpected medium were used to reach the client program's execution.

In cases where a boot program is split into multiple stages (like U-Boot), it only represents the device that was used to load the very first stage (in case of U-Boot, VPL/TPL/SPL whichever is executed first) and not any of the later stages (in case of U-Boot, TPL/SPL/proper) or any client program. They may match, but they may not and this property is meant to only represent the device used for loading the very first stage.

I have a board running U-Boot which currently has 9 boot scenarios (eMMC/SD/SPI-NOR for the first stage, eMMC/SD/SPI-NOR for the next stages; not counting USB loading yet, which would make it a few more). I cannot force the BootROM of this board to select a specific device aside from erasing the other media.
The only way to identify which device was used for the first stage is to parse U-Boot first stage console output or add some custom logic for my board. To validate that a new version of the bootloader works, including the fallback mechanisms, I need to make sure the BootROM loads the first stage from the expected device otherwise I may have false positives.

I could also very well see this being used to identify where the first stage of the boot program is stored (which may differ from where the later stages are! that's the case for U-Boot proper for example!) to be able to update it from a client program.

Note that Barebox has been using this property for a while already, with this very content[1].

A patch for the DT spec has already been sent[2].

[1] https://lore.kernel.org/u-boot/0066fcc2-3431-48be-8dc2-00ea7e2550c2@pengutronix.de/
[2] https://lore.kernel.org/devicetree-spec/20250505-bootsource-v2-1-5a315d9bff26@cherry.de/

Cc @a3f @sjg20 @robherring