### PR TITLE
schemas: pci-device: Allow wake-gpios property in device node

### DIFF
--- a/dtschema/schemas/pci/pci-device.yaml
+++ b/dtschema/schemas/pci/pci-device.yaml
@@ -59,6 +59,10 @@ properties:
     description: The PCI device ID
     $ref: /schemas/types.yaml#/definitions/uint32
 
+  wake-gpios:
+    description: GPIO controlled connection to WAKE# signal
+    maxItems: 1
+
 required:
   - reg
 


### PR DESCRIPTION
Right now, wake-gpios property is only allowed in the PCI bridge node along with reset-gpios property. This works perfectly fine for connectors conforming to the standards like PCIe CEM, M.2 and all components underneath sharing the same WAKE# signal.

But the spec didn't restrict the designers from connecting each WAKE# routed to the components to individual GPIOs in the host (assuming WAKE# is implemented as a GPIO). This was brought up while adding the WAKE# support in the PCI core for DT platforms in Linux Kernel:
https://lore.kernel.org/linux-pci/20250801212725.GA3506354@bhelgaas/

So allow the wake-gpios property to be defined in the endpoint nodes so that if separate GPIOs were routed for WAKE#, then it will allow the OS to identify each WAKE# signal connected to the components. This is not possible if the property is only available in the upstream bridge node.