### PR TITLE
schemas: add SDRAM consumer

### DIFF
--- a/dtschema/schemas/sdram/sdram-consumer.yaml
+++ b/dtschema/schemas/sdram/sdram-consumer.yaml
@@ -1,0 +1,22 @@
+# SPDX-License-Identifier: BSD-2-Clause
+# Copyright Clément Le Goffic <legoffic.clement@gmail.com>
+%YAML 1.2
+---
+$id: http://devicetree.org/schemas/sdram/sdram-consumer.yaml#
+$schema: http://devicetree.org/meta-schemas/core.yaml#
+
+title: SDRAM channel consumer properties
+
+maintainers:
+  - Clément Le Goffic <legoffic.clement@gmail.com>
+
+select: true
+
+properties:
+  memory-channel:
+    $ref: /schemas/types.yaml#/definitions/phandle
+    description:
+      Phandle to a memory channel node. This property references a node that
+      represents a SDRAM channel.
+
+additionalProperties: true


### PR DESCRIPTION
Add a new SDRAM consumer bindings.
Some peripherals may need to reference SDRAM channel, create the "memory-channel" to allow it.

Hello,
In my [linux kernel patch series](https://lore.kernel.org/all/20250909-b4-ddrperfm-upstream-v6-12-ce082cc801b5@gmail.com/), I have added this "memory-channel" property which allows my driver to get the DDR type of the platform's SDRAM channel.