### PR TITLE
README: Update Install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,8 +161,8 @@ This code depends on at least version 4.1.2 of the
 [Python jsonschema](https://github.com/Julian/jsonschema/tree/master)
 library for Draft 2019-09 support.
 
-The module can be installed directly from github with pip:
+The module can be installed with pip:
 
 ```
-pip3 install git+https://github.com/Julian/jsonschema.git
+pip3 install jsonschema-4.17.3
 ```

--- a/README.md
+++ b/README.md
@@ -147,15 +147,12 @@ Note: The above installation instructions handle all of the dependencies
 automatically.
 
 This code depends on Python 3 with the pylibfdt, ruamel.yaml, rfc3987, and jsonschema
-libraries. Installing pylibfdt depends on the 'swig' program.
+libraries. Building pylibfdt depends on the 'swig' program.
 
-On Debian/Ubuntu, the dependencies can be installed with apt and/or pip. The
-rfc3987 module is not packaged, so pip must be used:
+On Debian/Ubuntu, the dependencies can be installed with apt and/or pip.
 
 ```
-sudo apt install swig
-sudo apt install python3 python3-ruamel.yaml
-pip3 install rfc3987
+sudo apt install python3 python3-libfdt python3-ruamel.yaml python3-rfc3987
 ```
 
 


### PR DESCRIPTION
The installation instructions for the dependencies are outdated.
Update them to reflect the current state.