### PR TITLE
dt-bindings: chosen: Add "power-state-change-reason" nvmem property

### DIFF
--- a/dtschema/schemas/chosen.yaml
+++ b/dtschema/schemas/chosen.yaml
@@ -167,6 +167,18 @@ properties:
       will assign devices in its usual manner, otherwise it will not try to
       assign devices and instead use them as they are configured already.
 
+  nvmem-cells:
+    maxItems: 1
+    description:
+      A phandle to an NVMEM cell providing system-wide information.
+      Used in conjunction with 'nvmem-cell-names'.
+
+  nvmem-cell-names:
+    items:
+      - const: power-state-change-reason
+    description:
+      Indicates the NVMEM cell contains the last power state change reason
+
   stdout-path:
     $ref: types.yaml#/definitions/string
     pattern: "^[a-zA-Z0-9@/,+\\-._]*(:[0-9]*[noe]?[78]?[r]?)?$"


### PR DESCRIPTION
Hi all,

I'm proposing a new generic property for the /chosen node to identify
an NVMEM cell containing the last system shutdown/reboot reason. Many
embedded systems record this (e.g., "over-temperature", "brown-out"),
but there's no standard way to pass this location to the OS.

I'm sending this as an RFC patch because I'm uncertain about a few points:

1.  Is the /chosen node the right conceptual place for
    this? It feels correct for a global, firmware-provided property,
    much like 'stdout-path', but I'd
    like to be sure.

2.  Is this the right file to patch (`chosen.yaml`)? Or should this
    be defined in a more central NVMEM binding?

3.  Are the '$ref's correct? I'm referencing the existing meta-schema
    nvmem.yaml from schema (feels wrong). Is this the standard way to re-use
    properties from another schema?

Any feedback on the approach or the implementation would be greatly appreciated.

Thanks,
Oleksij