### PR TITLE
schemas: gpio: Add gpio-line schema and gpio-line-name for hogs

### DIFF
--- a/dtschema/dtb.py
+++ b/dtschema/dtb.py
@@ -415,7 +415,7 @@ def fixup_phandles(validator, dt, path=''):
 
 
 def fixup_gpios(dt):
-    if 'gpio-hog' in dt:
+    if 'gpio-hog' in dt or 'gpio-line' in dt:
         return
     for k, v in dt.items():
         if isinstance(v, dict):

--- a/dtschema/schemas/gpio/gpio-consumer.yaml
+++ b/dtschema/schemas/gpio/gpio-consumer.yaml
@@ -12,10 +12,11 @@ description: Schema for GPIO consumer devicetree bindings
 maintainers:
   - Rob Herring <robh@kernel.org>
 
-# do not select this schema for GPIO hogs
+# do not select this schema for GPIO hog/line child nodes
 select:
   properties:
     gpio-hog: false
+    gpio-line: false
 
 properties:
   gpios:

--- a/dtschema/schemas/gpio/gpio-line.yaml
+++ b/dtschema/schemas/gpio/gpio-line.yaml
@@ -1,30 +1,29 @@
 # SPDX-License-Identifier: BSD-2-Clause
-# Copyright 2018 Linaro Ltd.
 %YAML 1.2
 ---
-$id: http://devicetree.org/schemas/gpio/gpio-hog.yaml#
+$id: http://devicetree.org/schemas/gpio/gpio-line.yaml#
 $schema: http://devicetree.org/meta-schemas/base.yaml#
 
-title: GPIO Hog Nodes
+title: GPIO Line Nodes
 
-description: Schema for GPIO hog devicetree bindings
+description: Schema for GPIO line initialization devicetree bindings
 
 maintainers:
   - Rob Herring <robh@kernel.org>
 
-# select this schema for GPIO hogs
+# select this schema for GPIO line setup nodes
 select:
   properties:
-    gpio-hog: true
+    gpio-line: true
 
   required:
-    - gpio-hog
+    - gpio-line
 
 properties:
   $nodename:
-    pattern: "-hog(-[0-9]+)?$"
+    pattern: "-line(-[0-9]+)?$"
 
-  gpio-hog:
+  gpio-line:
     $ref: /schemas/types.yaml#/definitions/flag
 
   gpios:
@@ -33,28 +32,17 @@ properties:
   input:
     $ref: /schemas/types.yaml#/definitions/flag
 
-  line-name:
-    $ref: /schemas/types.yaml#/definitions/string
-
-  gpio-line-name:
-    $ref: /schemas/types.yaml#/definitions/string
-
   output-high:
     $ref: /schemas/types.yaml#/definitions/flag
 
   output-low:
     $ref: /schemas/types.yaml#/definitions/flag
 
-required:
-  - gpio-hog
-  - gpios
+  gpio-line-name:
+    $ref: /schemas/types.yaml#/definitions/string
 
-oneOf:
-  - required:
-      - input
-  - required:
-      - output-high
-  - required:
-      - output-low
+required:
+  - gpio-line
+  - gpios
 
 additionalProperties: false


### PR DESCRIPTION
Add a schema for gpio-line child nodes used to configure GPIO lines without hogging them.

Allow the optional gpio-line-name property on gpio-hog nodes.

Also treat gpio-line child nodes like gpio-hog nodes in the consumer schema selector and DTB GPIO fixups, since their gpios property is local and not a phandle array.

Linux kernel patchset:
V1: https://lore.kernel.org/all/20260213223204.2415507-1-james.hilliard1@gmail.com/
V2: https://lore.kernel.org/all/20260214213239.2546012-1-james.hilliard1@gmail.com/
V3: https://lore.kernel.org/all/20260216211021.3019827-1-james.hilliard1@gmail.com/