### PR TITLE
schemas: pci-bus-common: Add aspm-no-l1 property

### DIFF
--- a/dtschema/schemas/pci/pci-bus-common.yaml
+++ b/dtschema/schemas/pci/pci-bus-common.yaml
@@ -164,6 +164,10 @@ properties:
     description: Disables ASPM L0s capability
     type: boolean
 
+  aspm-no-l1:
+    description: Disables ASPM L1 capability
+    type: boolean
+
   aspm-l0s-entry-delay-ns:
     description: ASPM L0s entry delay
 


### PR DESCRIPTION
Some PCIe slots/bus segments exhibit link instability, functional failures etc when ASPM L1 is enabled. These issues are often caused by platform‑specific connectivity constraints such as PCB routing, connectors, slots, or external cables.

While the generic PCI bus binding already allows disabling ASPM L0s, there is currently no mechanism to independently disable ASPM L1 at the bus level.

Add an aspm-no-l1 boolean property to allow platforms to explicitly disable ASPM L1 for a given PCI bus node when required by board‑level or connectivity limitations.