### PR TITLE
schemas: pci-device: Restrict the T_POWER_ON value to 3100us

### DIFF
--- a/dtschema/schemas/pci/pci-device.yaml
+++ b/dtschema/schemas/pci/pci-device.yaml
@@ -64,6 +64,7 @@ properties:
     maxItems: 1
 
   t-power-on-us:
+    maximum: 3100
     description:
       The minimum amount of time that each component must wait in
       L1.2.Exit after sampling CLKREQ# asserted before actively driving


### PR DESCRIPTION
The maximum value of T_POWER_ON is going to be 3100us. So restrict the property as such.