### PR TITLE
schemas: pci-bus-common: Add 'aspm-no-l1ss' property

### DIFF
--- a/dtschema/schemas/pci/pci-bus-common.yaml
+++ b/dtschema/schemas/pci/pci-bus-common.yaml
@@ -168,6 +168,10 @@ properties:
     description: Disables ASPM L1 capability
     type: boolean
 
+  aspm-no-l1ss:
+    description: Disables ASPM L1 PM Substates capability
+    type: boolean
+
   aspm-l0s-entry-delay-ns:
     description: ASPM L0s entry delay
 


### PR DESCRIPTION
This property can be used by the OS to disable PCIe L1 PM Substates (L1.1 and L1.2) due to any hardware issues.

There is an existing 'supports-clkreq' property which is used to indicate that the CLKREQ# routing exists in the Slot. But this property cannot be used to disable L1ss due to any other hardware issues like PCB routing or cable issues. Also, this property is opt-in in nature, which will break backwards compatibility when used with existing DTS.

But this new property follows the precedence of existing APSM properties such as 'aspm-no-l0' and 'aspm-no-l1'.