### PR TITLE
json output and caching

### DIFF
--- a/dtschema/dtb.py
+++ b/dtschema/dtb.py
@@ -33,6 +33,12 @@ type_format = {
 }
 
 
+def _decode_error(validator, message):
+    print(message, file=sys.stderr)
+    if validator.decode_errors is not None:
+        validator.decode_errors.append(message)
+
+
 def bytes_to_string(b):
     try:
         strings = b.decode(encoding='ascii').split('\0')
@@ -191,8 +197,9 @@ def prop_value(validator, nodename, p):
     if {'flag'} & prop_types:
         if len(data):
             if fmt == 'flag':
-                print('{prop}: boolean property with value {val}'.format(prop=p.name, val=data),
-                      file=sys.stderr)
+                _decode_error(validator,
+                              '{prop}: boolean property with value {val}'.format(
+                                  prop=p.name, val=data))
                 return data
         else:
             return True
@@ -204,7 +211,9 @@ def prop_value(validator, nodename, p):
         for i in type_struct.iter_unpack(data):
             val_int += [dtschema.sized_int(i[0], size=(type_struct.size * 8))]
     except:
-        print('{prop}: size ({len}) error for type {fmt}'.format(prop=p.name, len=len(p), fmt=fmt), file=sys.stderr)
+        _decode_error(validator,
+                      '{prop}: size ({len}) error for type {fmt}'.format(
+                          prop=p.name, len=len(p), fmt=fmt))
         if len(p) == 4:
             type_struct = type_format['uint32']
         elif len(p) == 2:

--- a/dtschema/dtb_validate.py
+++ b/dtschema/dtb_validate.py
@@ -17,6 +17,33 @@ match_schema_file = None
 compatible_match = False
 
 
+def _display_path(filename):
+    abspath = os.path.abspath(filename)
+    relpath = os.path.relpath(abspath)
+
+    if relpath == os.pardir or relpath.startswith(os.pardir + os.path.sep):
+        return abspath
+    return relpath
+
+
+def _replace_filename_prefix(text, old, new):
+    lines = []
+    for line in text.splitlines(keepends=True):
+        stripped = line.lstrip()
+        prefix_len = len(line) - len(stripped)
+        if stripped.startswith(old + ':'):
+            line = line[:prefix_len] + new + stripped[len(old):]
+        lines.append(line)
+    return ''.join(lines)
+
+
+def _format_error(filename, error, nodename=None, compatible=None, verbose=False):
+    text = dtschema.format_error(filename, error, nodename=nodename,
+                                 compatible=compatible, verbose=verbose)
+    return _replace_filename_prefix(text, os.path.abspath(filename),
+                                    _display_path(filename))
+
+
 def _error_path(path):
     return [str(p) if not isinstance(p, int) else p for p in path]
 
@@ -49,7 +76,7 @@ def _error_diagnostic(filename, error, nodename=None, fullname=None, compatible=
     diagnostic = {
         'type': 'validation',
         'level': 'error',
-        'file': os.path.abspath(filename),
+        'file': _display_path(filename),
         'line': line,
         'column': column,
         'node': fullname,
@@ -80,7 +107,7 @@ def _unmatched_diagnostic(filename, fullname, node):
     return {
         'type': 'unmatched',
         'level': 'warning',
-        'file': os.path.abspath(filename),
+        'file': _display_path(filename),
         'line': None,
         'column': None,
         'node': fullname,
@@ -139,17 +166,19 @@ class schema_group():
                 if error.schema_file == 'generated-compatibles':
                     if not show_unmatched:
                         continue
+                    text = (f"{_display_path(filename)}: {fullname}: failed to match "
+                            f"any schema with compatible: {node['compatible']}")
                     self.emit_diagnostic(
                         _unmatched_diagnostic(filename, fullname, node),
-                        f"{filename}: {fullname}: failed to match any schema with compatible: {node['compatible']}")
+                        text)
                     continue
 
                 if 'compatible' in node:
                     compat = node['compatible'][0]
                 else:
                     compat = None
-                text = dtschema.format_error(filename, error, nodename=nodename,
-                                             compatible=compat, verbose=verbose)
+                text = _format_error(filename, error, nodename=nodename,
+                                     compatible=compat, verbose=verbose)
                 self.emit_diagnostic(
                     _error_diagnostic(filename, error, nodename=nodename, fullname=fullname,
                                       compatible=compat, formatted=text),
@@ -158,13 +187,14 @@ class schema_group():
             self.emit_diagnostic({
                 'type': 'recursion-error',
                 'level': 'error',
-                'file': os.path.abspath(filename),
+                'file': _display_path(filename),
                 'line': None,
                 'column': None,
                 'node': fullname,
                 'nodename': nodename,
                 'message': 'recursion error: Check for prior errors in a referenced schema',
-            }, os.path.basename(sys.argv[0]) + ": recursion error: Check for prior errors in a referenced schema")
+            }, os.path.basename(sys.argv[0]) +
+                ": recursion error: Check for prior errors in a referenced schema")
 
     def check_subtree(self, tree, subtree, disabled, nodename, fullname, filename):
         if nodename.startswith('__'):

--- a/dtschema/dtb_validate.py
+++ b/dtschema/dtb_validate.py
@@ -7,6 +7,7 @@ import sys
 import os
 import argparse
 import glob
+import json
 
 import dtschema
 
@@ -16,12 +17,92 @@ match_schema_file = None
 compatible_match = False
 
 
+def _error_path(path):
+    return [str(p) if not isinstance(p, int) else p for p in path]
+
+
+def _error_line_column(error):
+    linecol = getattr(error, 'linecol', (-1, -1))
+    if linecol[0] < 0:
+        return None, None
+    return linecol[0] + 1, linecol[1] + 1
+
+
+def _error_context(error):
+    context = {
+        'message': error.message,
+        'property_path': _error_path(error.absolute_path),
+        'schema_path': _error_path(error.absolute_schema_path),
+        'schema': getattr(error, 'schema_file', None),
+    }
+
+    note = getattr(error, 'note', None)
+    if note:
+        context['note'] = note
+
+    return context
+
+
+def _error_diagnostic(filename, error, nodename=None, fullname=None, compatible=None,
+                      formatted=None):
+    line, column = _error_line_column(error)
+    diagnostic = {
+        'type': 'validation',
+        'level': 'error',
+        'file': os.path.abspath(filename),
+        'line': line,
+        'column': column,
+        'node': fullname,
+        'nodename': nodename,
+        'compatible': compatible,
+        'property_path': _error_path(error.absolute_path),
+        'schema_path': _error_path(error.absolute_schema_path),
+        'schema': getattr(error, 'schema_file', None),
+        'message': error.message,
+    }
+
+    if formatted is not None:
+        diagnostic['formatted'] = formatted
+
+    note = getattr(error, 'note', None)
+    if note:
+        diagnostic['note'] = note
+
+    if error.context:
+        diagnostic['context'] = [_error_context(suberror)
+                                 for suberror in sorted(error.context, key=lambda e: e.path)]
+
+    return diagnostic
+
+
+def _unmatched_diagnostic(filename, fullname, node):
+    message = f"failed to match any schema with compatible: {node['compatible']}"
+    return {
+        'type': 'unmatched',
+        'level': 'warning',
+        'file': os.path.abspath(filename),
+        'line': None,
+        'column': None,
+        'node': fullname,
+        'nodename': os.path.basename(fullname) or fullname,
+        'compatible': node['compatible'],
+        'message': message,
+    }
+
+
 class schema_group():
-    def __init__(self, schema_file=""):
+    def __init__(self, schema_file="", json_output=False):
         if schema_file != "" and not os.path.exists(schema_file):
             exit(-1)
 
         self.validator = dtschema.DTValidator([schema_file])
+        self.json_output = json_output
+        self.diagnostics = []
+
+    def emit_diagnostic(self, diagnostic, text=None):
+        if self.json_output:
+            self.diagnostics.append(diagnostic)
+        sys.stderr.write((text if text is not None else diagnostic['message']) + "\n")
 
     def check_node(self, tree, node, disabled, nodename, fullname, filename):
         # Hack to save some time validating examples
@@ -58,19 +139,32 @@ class schema_group():
                 if error.schema_file == 'generated-compatibles':
                     if not show_unmatched:
                         continue
-                    print(f"{filename}: {fullname}: failed to match any schema with compatible: {node['compatible']}",
-                          file=sys.stderr)
+                    self.emit_diagnostic(
+                        _unmatched_diagnostic(filename, fullname, node),
+                        f"{filename}: {fullname}: failed to match any schema with compatible: {node['compatible']}")
                     continue
 
                 if 'compatible' in node:
                     compat = node['compatible'][0]
                 else:
                     compat = None
-                sys.stderr.write(
-                    dtschema.format_error(filename, error, nodename=nodename, compatible=compat, verbose=verbose) + "\n"
-                )
+                text = dtschema.format_error(filename, error, nodename=nodename,
+                                             compatible=compat, verbose=verbose)
+                self.emit_diagnostic(
+                    _error_diagnostic(filename, error, nodename=nodename, fullname=fullname,
+                                      compatible=compat, formatted=text),
+                    text)
         except RecursionError as e:
-            print(os.path.basename(sys.argv[0]) + ": recursion error: Check for prior errors in a referenced schema", file=sys.stderr)
+            self.emit_diagnostic({
+                'type': 'recursion-error',
+                'level': 'error',
+                'file': os.path.abspath(filename),
+                'line': None,
+                'column': None,
+                'node': fullname,
+                'nodename': nodename,
+                'message': 'recursion error: Check for prior errors in a referenced schema',
+            }, os.path.basename(sys.argv[0]) + ": recursion error: Check for prior errors in a referenced schema")
 
     def check_subtree(self, tree, subtree, disabled, nodename, fullname, filename):
         if nodename.startswith('__'):
@@ -117,6 +211,7 @@ def main():
         action="store_true")
     ap.add_argument('-n', '--line-number', help="Obsolete", action="store_true")
     ap.add_argument('-v', '--verbose', help="verbose mode", action="store_true")
+    ap.add_argument('--json-output', help="Write diagnostics in JSON format to the specified file")
     ap.add_argument('-u', '--url-path', help="Additional search path for references (deprecated)")
     ap.add_argument('-V', '--version', help="Print version number",
                     action="version", version=dtschema.__version__)
@@ -137,11 +232,11 @@ def main():
             match_schema_file[i] = match
 
     if args.preparse:
-        sg = schema_group(args.preparse)
+        sg = schema_group(args.preparse, bool(args.json_output))
     elif args.schema:
-        sg = schema_group(args.schema)
+        sg = schema_group(args.schema, bool(args.json_output))
     else:
-        sg = schema_group()
+        sg = schema_group(json_output=bool(args.json_output))
 
     for d in args.dtbs:
         if not os.path.isdir(d):
@@ -157,3 +252,8 @@ def main():
         if verbose:
             print("Check:  " + filename)
         sg.check_dtb(filename)
+
+    if args.json_output:
+        with open(args.json_output, 'w', encoding='utf-8') as f:
+            json.dump(sg.diagnostics, f, indent=2)
+            f.write('\n')

--- a/dtschema/dtb_validate.py
+++ b/dtschema/dtb_validate.py
@@ -7,7 +7,9 @@ import sys
 import os
 import argparse
 import glob
+import hashlib
 import json
+import tempfile
 
 import dtschema
 
@@ -15,6 +17,16 @@ verbose = False
 show_unmatched = False
 match_schema_file = None
 compatible_match = False
+CACHE_VERSION = 2
+CACHE_DTB_FILENAME = '$dtb'
+
+
+def _sha256_file(filename):
+    h = hashlib.sha256()
+    with open(filename, 'rb') as f:
+        for chunk in iter(lambda: f.read(1024 * 1024), b''):
+            h.update(chunk)
+    return h.hexdigest()
 
 
 def _display_path(filename):
@@ -117,17 +129,116 @@ def _unmatched_diagnostic(filename, fullname, node):
     }
 
 
+def _decode_diagnostic(filename, message):
+    return {
+        'type': 'decode',
+        'level': 'error',
+        'file': _display_path(filename),
+        'line': None,
+        'column': None,
+        'message': message,
+    }
+
+
+def _diagnostic_text(diagnostic):
+    if 'formatted' in diagnostic:
+        return diagnostic['formatted']
+    if diagnostic['type'] == 'unmatched':
+        return (f"{diagnostic['file']}: {diagnostic['node']}: "
+                f"{diagnostic['message']}")
+    if diagnostic['type'] == 'recursion-error':
+        return os.path.basename(sys.argv[0]) + ": " + diagnostic['message']
+    return diagnostic['message']
+
+
+def _emit_diagnostics(diagnostics):
+    for diagnostic in diagnostics:
+        sys.stderr.write(_diagnostic_text(diagnostic) + "\n")
+
+
+def _map_diagnostic_filename(value, old, new):
+    if isinstance(value, list):
+        return [_map_diagnostic_filename(v, old, new) for v in value]
+    if not isinstance(value, dict):
+        return value
+
+    mapped = {}
+    for key, val in value.items():
+        if key == 'file' and val == old:
+            mapped[key] = new
+        elif key == 'formatted' and isinstance(val, str):
+            mapped[key] = _replace_filename_prefix(val, old, new)
+        else:
+            mapped[key] = _map_diagnostic_filename(val, old, new)
+    return mapped
+
+
+class validation_cache():
+    def __init__(self, cache_dir, schema_file, options):
+        self.cache_dir = cache_dir
+        self.schema_hash = _sha256_file(schema_file) if schema_file else None
+        self.options = options
+
+    def _cache_key(self, filename):
+        key = {
+            'cache_version': CACHE_VERSION,
+            'dtschema_version': dtschema.__version__,
+            'dtb_hash': _sha256_file(filename),
+            'schema_hash': self.schema_hash,
+            'options': self.options,
+        }
+        data = json.dumps(key, sort_keys=True, separators=(',', ':'))
+        return hashlib.sha256(data.encode('utf-8')).hexdigest()
+
+    def _cache_file(self, key):
+        return os.path.join(self.cache_dir, key + '.json')
+
+    def load(self, filename):
+        cache_file = self._cache_file(self._cache_key(filename))
+        try:
+            with open(cache_file, 'r', encoding='utf-8') as f:
+                diagnostics = json.load(f)['diagnostics']
+                return _map_diagnostic_filename(diagnostics, CACHE_DTB_FILENAME,
+                                                _display_path(filename))
+        except (FileNotFoundError, KeyError, json.JSONDecodeError, OSError):
+            return None
+
+    def store(self, filename, diagnostics):
+        os.makedirs(self.cache_dir, exist_ok=True)
+        cache_file = self._cache_file(self._cache_key(filename))
+        data = {
+            'cache_version': CACHE_VERSION,
+            'diagnostics': _map_diagnostic_filename(diagnostics,
+                                                    _display_path(filename),
+                                                    CACHE_DTB_FILENAME),
+        }
+        fd, tmp = tempfile.mkstemp(prefix='.dt-validate-', suffix='.json',
+                                  dir=self.cache_dir, text=True)
+        try:
+            with os.fdopen(fd, 'w', encoding='utf-8') as f:
+                json.dump(data, f, indent=2)
+                f.write('\n')
+            os.replace(tmp, cache_file)
+        except Exception:
+            try:
+                os.unlink(tmp)
+            except OSError:
+                pass
+
+
 class schema_group():
-    def __init__(self, schema_file="", json_output=False):
+    def __init__(self, schema_file="", collect_diagnostics=False):
         if schema_file != "" and not os.path.exists(schema_file):
             exit(-1)
 
         self.validator = dtschema.DTValidator([schema_file])
-        self.json_output = json_output
+        self.collect_diagnostics = collect_diagnostics
         self.diagnostics = []
 
     def emit_diagnostic(self, diagnostic, text=None):
-        if self.json_output:
+        if text is not None and 'formatted' not in diagnostic:
+            diagnostic['formatted'] = text
+        if self.collect_diagnostics:
             self.diagnostics.append(diagnostic)
         sys.stderr.write((text if text is not None else diagnostic['message']) + "\n")
 
@@ -214,10 +325,28 @@ class schema_group():
 
     def check_dtb(self, filename):
         """Check the given DT against all schemas"""
+        self.diagnostics = []
+        decode_errors = []
         with open(filename, 'rb') as f:
-            dt = self.validator.decode_dtb(f.read())
+            dt = self.validator.decode_dtb(f.read(), decode_errors)
+        for error in decode_errors:
+            if self.collect_diagnostics:
+                self.diagnostics.append(_decode_diagnostic(filename, error))
         for subtree in dt:
             self.check_subtree(dt, subtree, False, "/", "/", filename)
+        return self.diagnostics
+
+
+def _dtb_filenames(dtbs):
+    for d in dtbs:
+        if not os.path.isdir(d):
+            continue
+        for filename in glob.iglob(d + "/**/*.dtb", recursive=True):
+            yield filename
+
+    for filename in dtbs:
+        if os.path.isfile(filename):
+            yield filename
 
 
 def main():
@@ -242,6 +371,8 @@ def main():
     ap.add_argument('-n', '--line-number', help="Obsolete", action="store_true")
     ap.add_argument('-v', '--verbose', help="verbose mode", action="store_true")
     ap.add_argument('--json-output', help="Write diagnostics in JSON format to the specified file")
+    ap.add_argument('--cache-dir',
+                    help="cache validation diagnostics in CACHE_DIR")
     ap.add_argument('-u', '--url-path', help="Additional search path for references (deprecated)")
     ap.add_argument('-V', '--version', help="Print version number",
                     action="version", version=dtschema.__version__)
@@ -261,29 +392,60 @@ def main():
                     match = match[(len(d) + 1):]
             match_schema_file[i] = match
 
+    schema_file = None
     if args.preparse:
-        sg = schema_group(args.preparse, bool(args.json_output))
+        schema_file = args.preparse
     elif args.schema:
-        sg = schema_group(args.schema, bool(args.json_output))
-    else:
-        sg = schema_group(json_output=bool(args.json_output))
+        schema_file = args.schema
 
-    for d in args.dtbs:
-        if not os.path.isdir(d):
-            continue
-        for filename in glob.iglob(d + "/**/*.dtb", recursive=True):
-            if verbose:
-                print("Check:  " + filename)
-            sg.check_dtb(filename)
+    cache = None
+    if args.cache_dir:
+        if schema_file is None or not os.path.isfile(schema_file):
+            print("--cache-dir requires a schema file", file=sys.stderr)
+            exit(-1)
+        cache_options = {
+            'compatible_match': compatible_match,
+            'limit': match_schema_file,
+            'show_unmatched': show_unmatched,
+            'verbose': verbose,
+        }
+        cache = validation_cache(args.cache_dir, schema_file, cache_options)
 
-    for filename in args.dtbs:
-        if not os.path.isfile(filename):
-            continue
+    collect_diagnostics = bool(args.json_output) or bool(cache)
+    sg = None
+    if args.preparse and not cache:
+        sg = schema_group(args.preparse, collect_diagnostics)
+    elif args.schema and not cache:
+        sg = schema_group(args.schema, collect_diagnostics)
+    elif not cache:
+        sg = schema_group(collect_diagnostics=collect_diagnostics)
+
+    diagnostics = []
+
+    for filename in _dtb_filenames(args.dtbs):
         if verbose:
             print("Check:  " + filename)
-        sg.check_dtb(filename)
+
+        cached = cache.load(filename) if cache else None
+        if cached is not None:
+            diagnostics += cached
+            _emit_diagnostics(cached)
+            continue
+
+        if sg is None:
+            if args.preparse:
+                sg = schema_group(args.preparse, collect_diagnostics)
+            elif args.schema:
+                sg = schema_group(args.schema, collect_diagnostics)
+            else:
+                sg = schema_group(collect_diagnostics=collect_diagnostics)
+
+        dtb_diagnostics = sg.check_dtb(filename)
+        diagnostics += dtb_diagnostics
+        if cache:
+            cache.store(filename, dtb_diagnostics)
 
     if args.json_output:
         with open(args.json_output, 'w', encoding='utf-8') as f:
-            json.dump(sg.diagnostics, f, indent=2)
+            json.dump(diagnostics, f, indent=2)
             f.write('\n')

--- a/dtschema/validator.py
+++ b/dtschema/validator.py
@@ -601,5 +601,9 @@ class DTValidator:
 
         return False
 
-    def decode_dtb(self, dtb):
-        return [dtschema.dtb.fdt_unflatten(self, dtb)]
+    def decode_dtb(self, dtb, decode_errors=None):
+        self.decode_errors = decode_errors
+        try:
+            return [dtschema.dtb.fdt_unflatten(self, dtb)]
+        finally:
+            self.decode_errors = None

--- a/test/test-dt-validate.py
+++ b/test/test-dt-validate.py
@@ -251,11 +251,70 @@ class TestDTValidate(unittest.TestCase):
             diagnostics = json.load(json_output)
 
         self.assertGreater(len(diagnostics), 0)
-        self.assertEqual(diagnostics[0]["type"], "validation")
-        self.assertEqual(diagnostics[0]["level"], "error")
-        self.assertIn("message", diagnostics[0])
-        self.assertIn("formatted", diagnostics[0])
-        self.assertIn("schema", diagnostics[0])
+        validation = next(d for d in diagnostics if d["type"] == "validation")
+        self.assertEqual(validation["level"], "error")
+        self.assertIn("message", validation)
+        self.assertIn("formatted", validation)
+        self.assertIn("schema", validation)
+
+    def test_cli_cache_output(self):
+        dtc = shutil.which('dtc')
+        if not dtc:
+            self.skipTest("dtc not found")
+
+        with tempfile.NamedTemporaryFile(suffix=".dtb") as f, \
+             tempfile.NamedTemporaryFile(suffix=".dtb") as f2, \
+             tempfile.NamedTemporaryFile(suffix=".json") as schema, \
+             tempfile.NamedTemporaryFile(suffix=".json") as json_output, \
+             tempfile.TemporaryDirectory() as cache_dir:
+            res = subprocess.run([dtc, '-Odtb', '-o', f.name, 'test/device-fail.dts'],
+                                 capture_output=True)
+            self.assertEqual(res.returncode, 0, msg='dtc failed:\n' + res.stderr.decode())
+            shutil.copyfile(f.name, f2.name)
+
+            res = subprocess.run([
+                sys.executable, '-c',
+                'import dtschema.mk_schema as m; m.main()',
+                '-j', '-o', schema.name, os.path.abspath('test/schemas')],
+                capture_output=True, text=True)
+            self.assertEqual(res.returncode, 0, msg=res.stderr)
+
+            cmd = [
+                sys.executable, '-c',
+                'import dtschema.dtb_validate as d; d.main()',
+                '--json-output', json_output.name, '--cache-dir', cache_dir,
+                '-s', schema.name, f.name]
+            res = subprocess.run(cmd, capture_output=True, text=True)
+            self.assertEqual(res.returncode, 0, msg=res.stderr)
+            self.assertEqual(res.stdout, "")
+            self.assertIn("from schema $id:", res.stderr)
+            self.assertIn("vendor,bool-prop: size (5) error for type flag", res.stderr)
+            json_output.seek(0)
+            first = json.load(json_output)
+            decode = next(d for d in first if d["type"] == "decode" and
+                          d["message"] == "vendor,bool-prop: size (5) error for type flag")
+            self.assertEqual(decode["file"], f.name)
+
+            res = subprocess.run(cmd, capture_output=True, text=True)
+            self.assertEqual(res.returncode, 0, msg=res.stderr)
+            self.assertEqual(res.stdout, "")
+            self.assertIn("from schema $id:", res.stderr)
+            self.assertIn("vendor,bool-prop: size (5) error for type flag", res.stderr)
+            json_output.seek(0)
+            self.assertEqual(json.load(json_output), first)
+            self.assertEqual(len(os.listdir(cache_dir)), 1)
+
+            cmd[-1] = f2.name
+            res = subprocess.run(cmd, capture_output=True, text=True)
+            self.assertEqual(res.returncode, 0, msg=res.stderr)
+            self.assertEqual(res.stdout, "")
+            self.assertIn("from schema $id:", res.stderr)
+            json_output.seek(0)
+            second = json.load(json_output)
+            validation = next(d for d in second if d["type"] == "validation")
+            self.assertEqual(validation["file"], f2.name)
+            self.assertTrue(validation["formatted"].startswith(f2.name + ":"))
+            self.assertEqual(len(os.listdir(cache_dir)), 1)
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test-dt-validate.py
+++ b/test/test-dt-validate.py
@@ -12,14 +12,18 @@ import unittest
 import os
 import copy
 import glob
+import json
+import shutil
 import sys
 import subprocess
 import tempfile
+from collections import deque
 
 basedir = os.path.dirname(__file__)
 import jsonschema
 import ruamel.yaml
 import dtschema
+import dtschema.dtb_validate
 
 dtschema_dir = os.path.dirname(dtschema.__file__)
 
@@ -139,6 +143,79 @@ class TestDTValidate(unittest.TestCase):
                         self.check_subtree('/', testtree[0])
                 else:
                     self.assertIsNone(self.check_subtree('/', testtree[0]))
+
+    def test_json_error_diagnostic(self):
+        error = jsonschema.ValidationError(
+            "'foo' is a required property",
+            path=deque(["soc", "device@0"]),
+            schema_path=deque(["then", "required"]))
+        error.linecol = (4, 8)
+        error.schema_file = "http://devicetree.org/schemas/test.yaml#"
+        error.note = "missing required property"
+
+        diagnostic = dtschema.dtb_validate._error_diagnostic(
+            "test.dtb", error, nodename="device@0", fullname="/soc/device@0",
+            compatible="test,device")
+
+        self.assertEqual(diagnostic["type"], "validation")
+        self.assertEqual(diagnostic["level"], "error")
+        self.assertEqual(diagnostic["file"], os.path.abspath("test.dtb"))
+        self.assertEqual(diagnostic["line"], 5)
+        self.assertEqual(diagnostic["column"], 9)
+        self.assertEqual(diagnostic["node"], "/soc/device@0")
+        self.assertEqual(diagnostic["nodename"], "device@0")
+        self.assertEqual(diagnostic["compatible"], "test,device")
+        self.assertEqual(diagnostic["property_path"], ["soc", "device@0"])
+        self.assertEqual(diagnostic["schema_path"], ["then", "required"])
+        self.assertEqual(diagnostic["schema"], "http://devicetree.org/schemas/test.yaml#")
+        self.assertEqual(diagnostic["message"], "'foo' is a required property")
+        self.assertEqual(diagnostic["note"], "missing required property")
+
+    def test_json_unmatched_diagnostic(self):
+        diagnostic = dtschema.dtb_validate._unmatched_diagnostic(
+            "test.dtb", "/soc/device@0", {"compatible": ["test,device"]})
+
+        self.assertEqual(diagnostic["type"], "unmatched")
+        self.assertEqual(diagnostic["level"], "warning")
+        self.assertEqual(diagnostic["file"], os.path.abspath("test.dtb"))
+        self.assertEqual(diagnostic["node"], "/soc/device@0")
+        self.assertEqual(diagnostic["compatible"], ["test,device"])
+        self.assertIn("failed to match any schema", diagnostic["message"])
+
+        diagnostic = dtschema.dtb_validate._unmatched_diagnostic(
+            "test.dtb", "/", {"compatible": ["test,board"]})
+        self.assertEqual(diagnostic["nodename"], "/")
+
+    def test_json_cli_output_file(self):
+        dtc = shutil.which('dtc')
+        if not dtc:
+            self.skipTest("dtc not found")
+
+        with tempfile.NamedTemporaryFile(suffix=".dtb") as dtb, \
+             tempfile.NamedTemporaryFile(suffix=".json") as json_output:
+            res = subprocess.run([dtc, '-Odtb', '-o', dtb.name, 'test/device-fail.dts'],
+                                 capture_output=True)
+            self.assertEqual(res.returncode, 0, msg='dtc failed:\n' + res.stderr.decode())
+
+            res = subprocess.run([
+                sys.executable, '-c',
+                'import dtschema.dtb_validate as d; d.main()',
+                '--json-output', json_output.name,
+                '-s', os.path.abspath('test/schemas'), dtb.name],
+                capture_output=True, text=True)
+
+            self.assertEqual(res.returncode, 0, msg=res.stderr)
+            self.assertEqual(res.stdout, "")
+            self.assertIn("from schema $id:", res.stderr)
+            json_output.seek(0)
+            diagnostics = json.load(json_output)
+
+        self.assertGreater(len(diagnostics), 0)
+        self.assertEqual(diagnostics[0]["type"], "validation")
+        self.assertEqual(diagnostics[0]["level"], "error")
+        self.assertIn("message", diagnostics[0])
+        self.assertIn("formatted", diagnostics[0])
+        self.assertIn("schema", diagnostics[0])
 
 
 

--- a/test/test-dt-validate.py
+++ b/test/test-dt-validate.py
@@ -159,7 +159,7 @@ class TestDTValidate(unittest.TestCase):
 
         self.assertEqual(diagnostic["type"], "validation")
         self.assertEqual(diagnostic["level"], "error")
-        self.assertEqual(diagnostic["file"], os.path.abspath("test.dtb"))
+        self.assertEqual(diagnostic["file"], "test.dtb")
         self.assertEqual(diagnostic["line"], 5)
         self.assertEqual(diagnostic["column"], 9)
         self.assertEqual(diagnostic["node"], "/soc/device@0")
@@ -177,7 +177,7 @@ class TestDTValidate(unittest.TestCase):
 
         self.assertEqual(diagnostic["type"], "unmatched")
         self.assertEqual(diagnostic["level"], "warning")
-        self.assertEqual(diagnostic["file"], os.path.abspath("test.dtb"))
+        self.assertEqual(diagnostic["file"], "test.dtb")
         self.assertEqual(diagnostic["node"], "/soc/device@0")
         self.assertEqual(diagnostic["compatible"], ["test,device"])
         self.assertIn("failed to match any schema", diagnostic["message"])
@@ -185,6 +185,46 @@ class TestDTValidate(unittest.TestCase):
         diagnostic = dtschema.dtb_validate._unmatched_diagnostic(
             "test.dtb", "/", {"compatible": ["test,board"]})
         self.assertEqual(diagnostic["nodename"], "/")
+
+    def test_format_error_rewrites_indented_paths(self):
+        filename = "test.dtb"
+        abs_filename = os.path.abspath(filename)
+
+        leaf = jsonschema.ValidationError(
+            "leaf problem",
+            path=deque(["leaf"]),
+            schema_path=deque(["type"]))
+        leaf.linecol = (2, 0)
+        leaf.schema_file = "http://devicetree.org/schemas/test.yaml#"
+
+        inner = jsonschema.ValidationError(
+            "inner problem",
+            path=deque(["inner"]),
+            schema_path=deque(["anyOf"]))
+        inner.linecol = (1, 0)
+        inner.schema_file = "http://devicetree.org/schemas/test.yaml#"
+        inner.context = [leaf]
+
+        other = jsonschema.ValidationError(
+            "other problem",
+            path=deque(["other"]),
+            schema_path=deque(["type"]))
+        other.linecol = (3, 0)
+        other.schema_file = "http://devicetree.org/schemas/test.yaml#"
+
+        error = jsonschema.ValidationError(
+            "outer problem",
+            path=deque(["root"]),
+            schema_path=deque(["then"]))
+        error.linecol = (0, 0)
+        error.schema_file = "http://devicetree.org/schemas/test.yaml#"
+        error.context = [inner, other]
+
+        text = dtschema.dtb_validate._format_error(filename, error, nodename="node")
+
+        self.assertNotIn(abs_filename, text)
+        self.assertIn("test.dtb:1:1", text)
+        self.assertIn("\ttest.dtb:2:1", text)
 
     def test_json_cli_output_file(self):
         dtc = shutil.which('dtc')
@@ -216,8 +256,6 @@ class TestDTValidate(unittest.TestCase):
         self.assertIn("message", diagnostics[0])
         self.assertIn("formatted", diagnostics[0])
         self.assertIn("schema", diagnostics[0])
-
-
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
In the DeviceTree source maintainer workflow, dt-validate is run repeatedly to catch regressions as well as improvements. This typically result in many similar validation passes against the same processed schema, with the need for structured output that can be compared between the runs.

Introduce the ability for dt-validate to produce json-formatted output of the validation results, and introduce a caching mechanism to avoid reevaluating unmodified files.