### PR TITLE
validator: Fix missing '#' stripping from schema ID

### DIFF
--- a/dtschema/validator.py
+++ b/dtschema/validator.py
@@ -519,7 +519,7 @@ class DTValidator:
 
             for v in val:
                 for sch_id in v['$id']:
-                    print(f"{self.schemas[sch_id]['$filename']}: {p}: multiple incompatible types: {v['type']}", file=sys.stderr)
+                    print(f"{self.schemas[sch_id.rstrip('#')]['$filename']}: {p}: multiple incompatible types: {v['type']}", file=sys.stderr)
 
     def make_property_type_cache(self):
         self.props, self.pat_props = get_prop_types(self.schemas)


### PR DESCRIPTION
Schema IDs contain a trailing '#' which is stripped to create a key to index the schemas dictionary. Stripping is missing in one location, which causes a KeyError exception when a property mixes multiple types:

Traceback (most recent call last):
  File "~/.local/bin/dt-mk-schema", line 6, in <module>
    sys.exit(main())
             ~~~~^^
  File "~/src/tools/dt-schema/dtschema/mk_schema.py", line 28, in main
    schemas = dtschema.DTValidator(args.schemas).schemas
              ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^
  File "~/src/tools/dt-schema/dtschema/validator.py", line 399, in __init__
    self.make_property_type_cache()
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "~/src/tools/dt-schema/dtschema/validator.py", line 528, in make_property_type_cache
    self.check_duplicate_property_types()
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "~/src/tools/dt-schema/dtschema/validator.py", line 522, in check_duplicate_property_types
    print(f"{self.schemas[sch_id]['$filename']}: {p}: multiple incompatible types: {v['type']}", file=sys.stderr)
             ~~~~~~~~~~~~^^^^^^^^
KeyError: 'http://devicetree.org/schemas/crypto/fsl,sec-v4.0.yaml#'

Fix it by stripping the trailing '#' like done in other locations.