### PR TITLE
schemas: reserved-memory: add linux,no-dump property

### DIFF
--- a/dtschema/schemas/reserved-memory/reserved-memory.yaml
+++ b/dtschema/schemas/reserved-memory/reserved-memory.yaml
@@ -93,6 +93,22 @@ properties:
       system can use that region to store volatile or cached data that
       can be otherwise regenerated or migrated elsewhere.
 
+  linux,no-dump:
+    type: boolean
+    description: >
+      If present, indicates that the Linux kernel should exclude this
+      reserved memory region from crash dumps (kdump vmcore). This is
+      typically used for firmware-owned carveouts (e.g. GPU, DSP, modem)
+      whose contents are not useful for kernel crash analysis and would
+      otherwise significantly inflate the vmcore size.
+
+      This property is an operating-system hint and has no effect on
+      hardware behaviour. It is ignored when combined with 'no-map'
+      (the region is already excluded from the kernel linear mapping
+      and therefore from vmcore) or with 'reusable' (the region is
+      actively used by the kernel for movable allocations and its
+      contents are relevant to crash analysis).
+
 allOf:
   - if:
       required:


### PR DESCRIPTION
Add a Linux-specific 'linux,no-dump' boolean property that marks a reserved memory region as one the Linux kernel should exclude from crash dumps (kdump vmcore).

Firmware-owned carveouts (GPU, DSP, modem) reserved via device tree typically contain data of no value for kernel crash analysis and can significantly inflate vmcore size. This property gives device tree authors a declarative way to request such regions to be filtered out when the elfcorehdr is constructed.

The property is named with a 'linux,' prefix because kdump is a Linux-specific concept; it is an OS hint rather than a hardware description, following the same convention as 'linux,cma-default' and 'linux,dma-default'.

As an OS hint, 'linux,no-dump' is silently ignored when combined with 'no-map' (already excluded from vmcore via the linear mapping) or 'reusable' (actively used by the kernel for movable allocations; its contents are valuable for crash analysis). Priority handling is implemented by the kernel at runtime, so no schema-level exclusion constraint is imposed, mirroring the permissive style of existing OS-hint properties.

The corresponding Linux kernel support is under review on LKML (https://lore.kernel.org/lkml/20260429065831.1510858-1-chenwandun@lixiang.com/).