### PR TITLE
Use sys.stderr.write() to fix stderr interleaving under make -jN

### DIFF
--- a/dtschema/doc_validate.py
+++ b/dtschema/doc_validate.py
@@ -27,7 +27,7 @@ def check_doc(filename):
 
     try:
         for error in sorted(dtsch.iter_errors(), key=lambda e: e.linecol):
-            print(dtschema.format_error(filename, error, verbose=verbose), file=sys.stderr)
+            sys.stderr.write(dtschema.format_error(filename, error, verbose=verbose) + "\n")
             ret = 1
     except:
         raise

--- a/dtschema/dtb_validate.py
+++ b/dtschema/dtb_validate.py
@@ -66,8 +66,9 @@ class schema_group():
                     compat = node['compatible'][0]
                 else:
                     compat = None
-                print(dtschema.format_error(filename, error, nodename=nodename, compatible=compat, verbose=verbose),
-                    file=sys.stderr)
+                sys.stderr.write(
+                    dtschema.format_error(filename, error, nodename=nodename, compatible=compat, verbose=verbose) + "\n"
+                )
         except RecursionError as e:
             print(os.path.basename(sys.argv[0]) + ": recursion error: Check for prior errors in a referenced schema", file=sys.stderr)
 

--- a/dtschema/schema.py
+++ b/dtschema/schema.py
@@ -205,7 +205,7 @@ class DTSchema(dict):
 
             if not (is_common or ref_has_constraint or has_constraint or
                (schema.keys() & {'additionalProperties', 'unevaluatedProperties'})):
-                print(f"{self.filename}: {parent}: Missing additionalProperties/unevaluatedProperties constraint\n",
+                print(f"{self.filename}: {parent}: Missing additionalProperties/unevaluatedProperties constraint",
                       file=sys.stderr)
 
             for k, v in schema.items():
@@ -222,10 +222,11 @@ class DTSchema(dict):
         base_path = self.filename[:-len(base1)]
         base2 = self.filename.replace(base_path, '')
         if not base1 == base2:
-            print(f"{self.filename}: $id: Cannot determine base path from $id, relative path/filename doesn't match actual path or filename\n",
-                  f"\t $id: {id}\n",
-                  f"\tfile: {self.filename}",
-                  file=sys.stderr)
+            sys.stderr.write(
+                f"{self.filename}: $id: Cannot determine base path from $id, relative path/filename doesn't match actual path or filename\n"
+                f"\t $id: {id}\n"
+                f"\tfile: {self.filename}\n"
+            )
             return
 
         self.paths = [

--- a/dtschema/validator.py
+++ b/dtschema/validator.py
@@ -416,8 +416,10 @@ class DTValidator:
                     compatibles = set(compatibles) - {'syscon', 'simple-mfd', 'simple-bus'}
                 for c in compatibles:
                     if not schema_cache and c in self.compat_map:
-                        print(f'Warning: Duplicate compatible "{c}" found in schemas matching "$id":\n'
-                              f'\t{self.compat_map[c]}\n\t{sch["$id"]}', file=sys.stderr)
+                        sys.stderr.write(
+                            f'Warning: Duplicate compatible "{c}" found in schemas matching "$id":\n'
+                            f'\t{self.compat_map[c]}\n\t{sch["$id"]}\n'
+                        )
                     self.compat_map[c] = _id
 
         self.schemas['version'] = dtschema.__version__


### PR DESCRIPTION
Example interleaved stderr:
```
/home/patchwise/build/arch/arm64/boot/dts/microchip/sparx5_pcb134_emmc.dtb: syscon@600000000 (microchip,sparx5-cpu-syscon): mux-controller:#mux-control-cells: 1 was expected
	from schema $id: http://devicetree.org/schemas/soc/microchip/microchip,sparx5-cpu-syscon.yaml/home/patchwise/build/arch/arm64/boot/dts/microchip/sparx5_pcb134.dtb: syscon@600000000 (microchip,sparx5-cpu-syscon): mux-controller:#mux-control-cells: 1 was expected
	from schema $id: http://devicetree.org/schemas/soc/microchip/microchip,sparx5-cpu-syscon.yaml
```

This issue was found when running `make -j$(nproc) dtbs_check` in [PatchWise](https://github.com/qualcomm/PatchWise) (automates patch review and static analysis):

https://github.com/qualcomm/PatchWise/blob/main/patchwise/patch_review/static_analysis/dtbs_check.py#L36-L51

This makes it difficult for automations to find the diff between before and after errors of the current commit.

The root cause is that on Python's default line-buffered sys.stderr, print() makes 2 write() syscalls when
the input is a multi-line string, and a sibling process' write() can execute between those two syscalls.

single-line print() -> 1 write() syscall.
ex: print("msg\n") -> 1 write()

multi-line print() -> 2 write() syscalls.
ex: print(" line1 \n line2 \n line3 ") -> 2 write() syscalls
  - one for "line1 \n line2 \n line3"
  - one for "\n" that print() adds at the end

Python's sys.stderr is line-buffered by default, so the pending buffer gets flushed when "\n" is seen.

```
p1                                             p2
write(" line1 \n line2 \n line3 ")
                                            write("msg\n")
write("\n")
```

Output:
```
 line1
 line2
 line3 msg

```

This can be proven by running strace on something like this:

```python
import sys


def banner(label):
    sys.stderr.write(f"=== {label} ===\n")
    sys.stderr.flush()


banner("print(single-line)")
print("ABCDEFGH" * 4, file=sys.stderr)
sys.stderr.flush()

banner("print(multi-line)")
print("LINE1-XX\nLINE2-XX\nLINE3-XX", file=sys.stderr)
sys.stderr.flush()

banner("write(multi-line + '\\n')")
sys.stderr.write("LINE1-XX\nLINE2-XX\nLINE3-XX" + "\n")
sys.stderr.flush()
```

```bash
$ strace -f -e trace=write -e signal=none -o trace_print.strace python3 trace_print.py 2>trace_print.out
$ grep 'write(2,' trace_print.strace
2804383 write(2, "=== print(single-line) ===\n", 27) = 27
2804383 write(2, "ABCDEFGHABCDEFGHABCDEFGHABCDEFGH"..., 33) = 33
2804383 write(2, "=== print(multi-line) ===\n", 26) = 26
2804383 write(2, "LINE1-XX\nLINE2-XX\nLINE3-XX", 26) = 26
2804383 write(2, "\n", 1)               = 1
2804383 write(2, "=== write(multi-line + '\\n') ==="..., 33) = 33
2804383 write(2, "LINE1-XX\nLINE2-XX\nLINE3-XX\n", 27) = 27

$ cat trace_print.out
=== print(single-line) ===
ABCDEFGHABCDEFGHABCDEFGHABCDEFGH
=== print(multi-line) ===
LINE1-XX
LINE2-XX
LINE3-XX
=== write(multi-line + '\n') ===
LINE1-XX
LINE2-XX
LINE3-XX
```

Fix the issue by using sys.stderr.write(text + "\n") instead of print(text, file=sys.stderr),
since sys.stderr.write(multi_line_text) makes a single write() call.