### PR TITLE
meta-schemas: Exclude "xlnx,channels" from vendor properties

### DIFF
--- a/dtschema/meta-schemas/vendor-props.yaml
+++ b/dtschema/meta-schemas/vendor-props.yaml
@@ -12,6 +12,9 @@ properties:
   adi,channels:
     type: object
 
+  xlnx,channels:
+    type: object
+
 patternProperties:
   '[\[\]*{}$\^\\]+': true # exclude regex's
   '^[^,]*$': true


### PR DESCRIPTION
"xlnx,channels" is a node name which is in use. Add it to the exceptions.

Link: https://lore.kernel.org/linux-iio/20260510083219.70224-1-pramod.nexgen@gmail.com/