### PR TITLE
schemas: Add usb4-host-interface

### DIFF
--- a/dtschema/schemas/usb4-host-interface.yaml
+++ b/dtschema/schemas/usb4-host-interface.yaml
@@ -1,0 +1,40 @@
+# SPDX-License-Identifier: BSD-2-Clause
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+%YAML 1.2
+---
+$id: http://devicetree.org/schemas/usb4-host-interface.yaml#
+$schema: http://devicetree.org/meta-schemas/core.yaml#
+
+title: USB4-tunneled native protocol controller properties.
+
+description:
+  The USB4 protocol allows for tunneling of other protocols through
+  encapsulation.
+  A system implementing a USB4 host router contains both the native protocol
+  controllers and a USB4 router. The host router contains a number of protocol
+  adapters (as defined in the USB4 specification), which convert the traffic
+  between the tunneled packets and native signaling.
+
+maintainers:
+  - Konrad Dybcio <konradybcio@kernel.org>
+
+select: true
+
+properties:
+  usb4-host-interface:
+    $ref: /schemas/types.yaml#/definitions/phandle
+    description:
+      Phandle to the USB4 router this device is connected to.
+
+additionalProperties: true
+
+examples:
+  - |
+    usb@10000 {
+        compatible = "vendor,device-id";
+        reg = <0x10000 0x1000>;
+
+        usb4-host-interface = <&usb4_router0>;
+    };
+
+...


### PR DESCRIPTION
For USB4 tunneling, the native protocol controllers (PCIe, DP, USB3) must be linked to the USB4 router, so that the OS is aware of their relationship, making it possible to power sequence them properly.

Add a schema to allow usb4-host-interface property, following the existing ACPI bindings used on both Linux and Windows.

Link: https://www.usb.org/sites/default/files/D1T2-2%20-%20USB4%20on%20Windows.pdf
Link: https://learn.microsoft.com/en-us/windows-hardware/design/component-guidelines/usb4-acpi-requirements
Link: https://learn.microsoft.com/en-us/windows-hardware/drivers/pci/dsd-for-pcie-root-ports