### PR TITLE
schemas: reserved-memory: clarify reg supports a single entry only

### DIFF
--- a/dtschema/schemas/reserved-memory/reserved-memory.yaml
+++ b/dtschema/schemas/reserved-memory/reserved-memory.yaml
@@ -16,7 +16,7 @@ description: >
   memory regions. Such memory regions are usually designed for the special
   usage by various device drivers.
 
-  Each child of the reserved-memory node specifies one or more regions
+  Each child of the reserved-memory node specifies one region
   of reserved memory. Each child node may either use a 'reg' property to
   specify a specific range of reserved memory, or a 'size' property with
   optional constraints to request a dynamically allocated block of
@@ -28,7 +28,8 @@ description: >
   is a static allocation.
 
 properties:
-  reg: true
+  reg:
+    maxItems: 1
 
   size:
     oneOf:


### PR DESCRIPTION
The existing description is internally inconsistent. The opening sentence says "Each child of the reserved-memory node specifies one or more regions of reserved memory", but the next sentence narrows this to a singular form: "Each child node may either use a 'reg' property to specify a specific range of reserved memory, or a 'size' property ... to request a dynamically allocated block of memory"

Multiple entries in 'reg' have never been fully functional in the Linux kernel, so drop the "one or more" wording and add 'maxItems: 1' to the reg property.

Suggested-by: Rob Herring <robh@kernel.org>
Link: https://lore.kernel.org/all/20260506014752.GA280279-robh@kernel.org/

The corresponding Linux kernel support is under review on LKML
( https://lore.kernel.org/lkml/20260525121700.2706141-1-chenwandun1@gmail.com/)