### PR TITLE
schemas: net: add PCS producer/consumer common property

### DIFF
--- a/dtschema/schemas/net/pcs-consumer.yaml
+++ b/dtschema/schemas/net/pcs-consumer.yaml
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: BSD-2-Clause
+%YAML 1.2
+---
+$id: http://devicetree.org/schemas/net/pcs-consumer.yaml#
+$schema: http://devicetree.org/meta-schemas/base.yaml#
+
+title: PCS Consumer Common Properties
+
+maintainers:
+  - Christian Marangi <ansuelsmth@gmail.com>
+
+# always select the core schema
+select: true
+
+properties:
+  pcs-handle:
+    $ref: /schemas/types.yaml#/definitions/phandle-array
+
+  pcs-names:
+    $ref: /schemas/types.yaml#/definitions/string-array
+
+dependencies:
+  pcs-names: [ pcs-handle ]
+
+additionalProperties: true

--- a/dtschema/schemas/net/pcs-provider.yaml
+++ b/dtschema/schemas/net/pcs-provider.yaml
@@ -1,0 +1,19 @@
+# SPDX-License-Identifier: BSD-2-Clause
+---
+$id: http://devicetree.org/schemas/net/pcs-provider.yaml#
+$schema: http://devicetree.org/meta-schemas/base.yaml#
+
+title: PCS Provider Common Properties
+
+maintainers:
+  - Christian Marangi <ansuelsmth@gmail.com>
+
+# always select the core schema
+select: true
+
+properties:
+  '#pcs-cells': true
+
+additionalProperties: true
+
+...


### PR DESCRIPTION
Add simple schemas to document the common property of a Network PCS producer/consumer with related cells and pcs-handle/pcs-names.

---

This is related to the RFC series for the PCS series on net-next.