### PR TITLE
dtb: add 'wakeup-source' property to phandle_args

### DIFF
--- a/dtschema/dtb.py
+++ b/dtschema/dtb.py
@@ -321,6 +321,7 @@ phandle_args = {
     'msi-ranges': '#interrupt-cells',
     'dma-masters': '#dma-cells',
     'gpio-ranges': 3,
+    'wakeup-source': 0,
 
     'memory-region': None,
 }


### PR DESCRIPTION
Add 'wakeup-source' property to phandle_args since the property can be of phandle-array type, but can only have a fixed phandle arg size of 0 for each entry.

Fixes warning on TI K3 device trees that use the 'wakeup-source' property with phandle-arrays:
```
arch/arm64/boot/dts/ti/k3-am62-lp-sk.dtb: can@4e08000 (bosch,m_can): wakeup-source: 'oneOf' conditional failed, one must be fixed:
         [[9, 10, 11, 12]] is not of type 'boolean'
         [9, 10, 11, 12] is too long
         from schema $id: http://devicetree.org/schemas/wakeup-source.yaml
```

where the warning is that the array is too long since 'maxItems' is 1 for the phandle-array elements.