### PR TITLE
schemas: mbox: Add mbox-controller and update mbox-consumer

### DIFF
--- a/dtschema/schemas/mbox/mbox-consumer.yaml
+++ b/dtschema/schemas/mbox/mbox-consumer.yaml
@@ -17,16 +17,33 @@ select: true
 properties:
   mboxes:
     $ref: /schemas/types.yaml#/definitions/phandle-array
+    description: >
+      List of mailboxes used by the client. Each entry in the list will be
+      a phandle pointing to a mailbox controller followed by some number of
+      controller-defined (via #mbox-cells) extra cells.
 
   mbox-names:
     $ref: /schemas/types.yaml#/definitions/string-array
+    description: >
+      List of names corresponding to mailboxes in the mboxes list.
 
   shmem:
     $ref: /schemas/types.yaml#/definitions/phandle-array
     items:
       maxItems: 1
+    description: >
+      List of phandles to memory regions associated with mailboxes in the
+      mboxes list.
 
 dependencies:
   mbox-names: [ mboxes ]
 
 additionalProperties: true
+
+examples:
+  - |
+    device {
+        mboxes = <&mailbox 0>, <&mailbox 1>;
+        mbox-names = "tx", "rx";
+    };
+...

--- a/dtschema/schemas/mbox/mbox-controller.yaml
+++ b/dtschema/schemas/mbox/mbox-controller.yaml
@@ -1,0 +1,32 @@
+# SPDX-License-Identifier: BSD-2-Clause
+# Copyright 2026 Arm Ltd.
+%YAML 1.2
+---
+$id: http://devicetree.org/schemas/mbox/mbox-controller.yaml#
+$schema: http://devicetree.org/meta-schemas/base.yaml#
+
+title: Mailbox Controller Common Properties
+
+maintainers:
+  - Rob Herring <robh@kernel.org>
+
+# always select the core schema
+select: true
+
+properties:
+  '#mbox-cells':
+    $ref: /schemas/types.yaml#/definitions/uint32
+    minimum: 0
+    description: >
+      Number of cells in a mailbox specifier.
+      When #mbox-cells is 0, the controller is a single-channel mailbox.
+      When #mbox-cells is 1, the cell typically contains the channel ID.
+
+additionalProperties: true
+
+examples:
+  - |
+    mailbox: mailbox {
+        #mbox-cells = <1>;
+    };
+...


### PR DESCRIPTION
As per mailing-list discussions [1] [2] [3], we want to delete the following old file from the device-tree bindings that live in the Linux kernel git tree:
* Documentation/devicetree/bindings/mailbox/mailbox.txt

Move descriptive text from that old file here into mbox-consumer.yaml. Add a simple example to the file as well.

Create a new mbox-controller.yaml file as a place to document `#mbox-cells`. Even though the previous text file said it needed to be at least 1, grepping through existing device tree source files show plenty of examples of `#mbox-cells = <0>`.

Link: http://lore.kernel.org/r/20260722140214.GA548057-robh@kernel.org [1]
Link: https://lore.kernel.org/r/dc7a2041-50a4-482e-9930-566bb3fd1e72@kernel.org [2]
Link: https://lore.kernel.org/r/CAL_JsqKVjQ2m-dzMUENQry-f_YE9QrYSOKoH9CPj1gjj8XkPRA@mail.gmail.com [3]