### PR TITLE
validator: Cache jsonschema validators

### DIFF
--- a/dtschema/validator.py
+++ b/dtschema/validator.py
@@ -428,6 +428,24 @@ class DTValidator:
                     self.compat_map[c] = _id
 
         self.schemas['version'] = dtschema.__version__
+        self._schema_validators = {}
+        self._select_validators = {}
+
+    def _schema_validator(self, schema_id):
+        validator = self._schema_validators.get(schema_id)
+        if validator is None:
+            validator = self.DtValidator(self.schemas[schema_id], registry=self.registry)
+            self._schema_validators[schema_id] = validator
+        return validator
+
+    def _select_validator(self, schema_id):
+        validator = self._select_validators.get(schema_id)
+        if validator is None:
+            schema = {'if': self.schemas[schema_id]['select'],
+                      'then': self.schemas[schema_id]}
+            validator = self.DtValidator(schema, registry=self.registry)
+            self._select_validators[schema_id] = validator
+        return validator
 
     def retrieve(self, uri):
         try:
@@ -455,8 +473,7 @@ class DTValidator:
                 if inst_compat in self.compat_map:
                     schema_id = self.compat_map[inst_compat]
                     if self._filter_match(schema_id, filter):
-                        schema = self.schemas[schema_id]
-                        for error in self.DtValidator(schema, registry=self.registry).iter_errors(instance):
+                        for error in self._schema_validator(schema_id).iter_errors(instance):
                             self.annotate_error(schema_id, error)
                             yield error
                     break
@@ -467,9 +484,7 @@ class DTValidator:
         for schema_id in self.always_schemas:
             if not self._filter_match(schema_id, filter):
                 continue
-            schema = {'if': self.schemas[schema_id]['select'],
-                      'then': self.schemas[schema_id]}
-            for error in self.DtValidator(schema, registry=self.registry).iter_errors(instance):
+            for error in self._select_validator(schema_id).iter_errors(instance):
                 self.annotate_error(schema_id, error)
                 yield error
 

--- a/test/test-dt-validate.py
+++ b/test/test-dt-validate.py
@@ -144,6 +144,24 @@ class TestDTValidate(unittest.TestCase):
                 else:
                     self.assertIsNone(self.check_subtree('/', testtree[0]))
 
+    def test_validator_cache(self):
+        node = {
+            '$nodename': ['test'],
+            'compatible': ['vendor,soc1-ip'],
+            'vendor,int-prop': [4],
+        }
+        errors = [error.message for error in self.validator.iter_errors(node)]
+        schema_id = self.validator.compat_map['vendor,soc1-ip']
+        schema_validator = self.validator._schema_validators[schema_id]
+        select_validators = self.validator._select_validators.copy()
+
+        self.assertTrue(errors)
+        self.assertEqual(errors, [error.message for error in self.validator.iter_errors(node)])
+        self.assertIs(self.validator._schema_validators[schema_id], schema_validator)
+        self.assertEqual(self.validator._select_validators.keys(), select_validators.keys())
+        for select_id, validator in select_validators.items():
+            self.assertIs(self.validator._select_validators[select_id], validator)
+
     def test_json_error_diagnostic(self):
         error = jsonschema.ValidationError(
             "'foo' is a required property",


### PR DESCRIPTION
DTValidator creates jsonschema validator instances for every node it checks. This repeats setup for bindings selected by compatible strings and for every select schema in a tree.

Cache these validators for the lifetime of a DTValidator, whose schemas and registry are fixed. The cache preserves validation output and avoids repeated setup work.

Across a sample of Qualcomm arm64 DTBs from a Linux tree with a processed Linux schema, median validation time improved with 20.3%.