### PR TITLE
schemas: chosen: allow a boot logo node

### DIFF
--- a/dtschema/schemas/chosen.yaml
+++ b/dtschema/schemas/chosen.yaml
@@ -90,6 +90,13 @@ properties:
 
       This random value should be provided by bootloader.
 
+  logo:
+    type: object
+    description:
+      A boot logo supplied by firmware, as an image the operating system can
+      draw once it owns the display. The contents are described by the
+      binding matching the node's compatible string.
+
   linux,booted-from-kexec:
     type: boolean
     description:


### PR DESCRIPTION
A boot logo supplied by firmware is configuration rather than a description of
the hardware, so it belongs under `/chosen`, in the same spirit as the
`oem-logo` variable Open Firmware carried under `/options`, and in the same
company as `simple-framebuffer`.

A Linux binding for such a node, `linux,boot-logo-clut224`, is being proposed
on the kernel lists:

  https://lore.kernel.org/all/20260804225617.264861-1-maximpedraza@gmail.com/

`chosen.yaml` currently allows only `^framebuffer` under `/chosen`, so
`dtbs_check` rejects the node on any board that uses it:

```
board.dtb: chosen: 'logo' does not match any of the regexes:
    '^framebuffer', '^pinctrl-[0-9]+$'
	from schema $id: http://devicetree.org/schemas/chosen.yaml
```

This allows it. The name is fixed, so it goes in `properties` rather than
`patternProperties` -- an anchored pattern there is rejected by the
metaschema, which says fixed strings belong in `properties`. As with
`framebuffer`, the contents are not validated here: the node is matched by
its own binding through its compatible string, and the kernel binding pins
the name with `$nodename: const: logo`.

Tested against two device trees, one carrying the image in the node and one
pointing at a reserved memory region: the error above goes from 1 to 0 on
both, with no other change in `dt-validate` output.
